### PR TITLE
Added set_seed for deterministic random number gernation

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ exports.replaceSymbolWithNumber = function (string, symbol) {
     var str = '';
     for (var i = 0; i < string.length; i++) {
         if (string[i] == symbol) {
-            str += Math.floor(Math.random() * 10);
+            str += Math.floor(exports.randomNumber(10));
         } else {
             str += string[i];
         }
@@ -35,7 +35,7 @@ exports.replaceSymbolWithNumber = function (string, symbol) {
 
 // takes an array and returns it randomized
 exports.shuffle = function (o) {
-    for (var j, x, i = o.length; i; j = parseInt(Math.random() * i, 10), x = o[--i], o[i] = o[j], o[j] = x);
+    for (var j, x, i = o.length; i; j = parseInt(exports.randomNumber(i), 10), x = o[--i], o[i] = o[j], o[j] = x);
     return o;
 };
 

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -28,7 +28,7 @@ var internet = {
 
     ip: function () {
         var randNum = function () {
-            return (Math.random() * 254 + 1).toFixed(0);
+            return (Faker.random.number(254) + 1).toFixed(0);
         };
 
         var result = [];

--- a/lib/random.js
+++ b/lib/random.js
@@ -23,7 +23,7 @@ var random = {
 
     // takes an array and returns the array randomly sorted
     array_element: function (array) {
-        var r = Math.floor(Math.random() * array.length);
+        var r = Math.floor(random.number(array.length));
         return array[r];
     },
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -1,6 +1,21 @@
 var definitions = require('./definitions');
+var crypto = require('crypto');
 
 var random = {
+    // set a seed for and replace the random number generator
+    set_seed: function(seed) {
+        random.number = (function() {
+            var seq = 0;
+
+            return function(max) {
+                return parseInt(
+                    crypto.createHash('md5')
+                        .update("" + seed + (seq++))
+                        .digest('hex')
+                , 16) % max;
+            };
+        })();
+    },
     // returns a single random number based on a range
     number: function (range) {
         return Math.floor(Math.random() * range);


### PR DESCRIPTION
Change the placers Faker calls Math.rand to use Faker.random.number. This allows overriding Faker.random.number for libraries who wish to do so. This change compliments the set_seed method for deterministic random number generation.