### PR TITLE
lorem.sentences takes a second argument to specify glue.

### DIFF
--- a/lib/lorem.js
+++ b/lib/lorem.js
@@ -18,13 +18,16 @@ var lorem = {
         return  this.words(wordCount + faker.random.number(7)).join(' ');
     },
 
-    sentences: function (sentenceCount) {
+    sentences: function (sentenceCount, glue) {
+        glue = glue ? glue : '. ';
+
         if (typeof sentenceCount == 'undefined') { sentenceCount = 3; }
         var sentences = [];
         for (sentenceCount; sentenceCount > 0; sentenceCount--) {
-            sentences.push(this.sentence());
+            sentences.push(faker.Lorem.sentence());
         }
-        return sentences.join("\n");
+
+        return sentences.join(glue);
     },
 
     paragraph: function (sentenceCount) {


### PR DESCRIPTION
It's convenient to have the ability to specify the string used to glue sentences. You parse JSON out of the generated content as it currently is since `\n` is invalid.