### PR TITLE
Update Readme.md to point to correct Travis URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # faker.js - generate massive amounts of fake data in the browser and node.js
 <img src = "http://imgur.com/KiinQ.png" border = "0">
 
-[![Build Status](https://travis-ci.org/Marak/faker.js.svg?branch=master)](https://travis-ci.org/Marak/Faker.js)
+[![Build Status](https://travis-ci.org/Marak/faker.js.svg?branch=master)](https://travis-ci.org/Marak/faker.js)
 
 ## Demo
 


### PR DESCRIPTION
The URL which Build Status badge links to returns a 404 due to an accidental capitalization in the URL