### PR TITLE
Make company suffix function use data from locale instead of hard-coded data

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ exports.definitions = {};
 var _definitions = {
   "name": ["first_name", "last_name", "prefix", "suffix"],
   "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "state", "state_abbr"],
-  "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb"],
+  "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb", "suffix"],
   "lorem": ["words"],
   "hacker": ["abbreviation", "adjective", "noun", "verb", "ingverb"],
   "phone_number": ["formats"],

--- a/lib/company.js
+++ b/lib/company.js
@@ -3,7 +3,8 @@ var faker = require('../index');
 var company = {
 
     suffixes: function () {
-        return ["Inc", "and Sons", "LLC", "Group", "and Daughters"];
+        // Don't want the source array exposed to modification, so return a copy
+        return faker.definitions.company.suffix.slice(0);
     },
 
     companyName: function (format) {


### PR DESCRIPTION
The `company.suffixes` function was returning a hard-coded array of English suffixes. Modify it to return the suffixes provided in the locale file instead.