### PR TITLE
Add new jobTitle function to name object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ exports.localeFallback = "en";
 exports.definitions = {};
 
 var _definitions = {
-  "name": ["first_name", "last_name", "prefix", "suffix"],
+  "name": ["first_name", "last_name", "prefix", "suffix", "title"],
   "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "state", "state_abbr"],
   "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb"],
   "lorem": ["words"],

--- a/lib/name.js
+++ b/lib/name.js
@@ -44,6 +44,12 @@ var _name = {
         return firstName + " " + lastName;
     },
 
+    jobTitle: function () {
+      return  faker.name.jobDescriptor() + " " +
+        faker.name.jobArea() + " " +
+        faker.name.jobType();
+    },
+
     prefix: function () {
         return faker.random.array_element(faker.definitions.name.prefix);
     },
@@ -51,6 +57,20 @@ var _name = {
     suffix: function () {
         return faker.random.array_element(faker.definitions.name.suffix);
     },
+
+    jobDescriptor: function () {
+      return faker.random.array_element(faker.definitions.name.title.descriptor);
+    },
+
+    jobArea: function () {
+      return faker.random.array_element(faker.definitions.name.title.level);
+    },
+
+    jobType: function () {
+      return faker.random.array_element(faker.definitions.name.title.job);
+    }
+
+
 
 };
 

--- a/test/all.functional.js
+++ b/test/all.functional.js
@@ -18,7 +18,7 @@ var modules = {
 
     lorem: ['words', 'sentence', 'sentences', 'paragraph', 'paragraphs'],
 
-    name: ['firstName', 'lastName', 'findName'],
+    name: ['firstName', 'lastName', 'findName', 'jobTitle'],
 
     phone: ['phoneNumber'],
 

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -44,6 +44,7 @@ describe("internet.js", function () {
             faker.random.number.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
+            faker.random.array_element.restore();
         });
     });
 

--- a/test/name.unit.js
+++ b/test/name.unit.js
@@ -67,4 +67,25 @@ describe("name.js", function () {
             var name = faker.name.findName();
         });
     });
+
+    describe("jobTitle()", function () {
+        it("returns a job title consisting of a descriptor, area, and type", function () {
+            sinon.spy(faker.random, 'array_element');
+            sinon.spy(faker.name, 'jobDescriptor');
+            sinon.spy(faker.name, 'jobArea');
+            sinon.spy(faker.name, 'jobType');
+            var jobTitle = faker.name.jobTitle();
+
+            assert.ok(typeof jobTitle === 'string');
+            assert.ok(faker.random.array_element.calledThrice);
+            assert.ok(faker.name.jobDescriptor.calledOnce);
+            assert.ok(faker.name.jobArea.calledOnce);
+            assert.ok(faker.name.jobType.calledOnce);
+
+            faker.random.array_element.restore();
+            faker.name.jobDescriptor.restore();
+            faker.name.jobArea.restore();
+            faker.name.jobType.restore();
+        });
+    });
 });


### PR DESCRIPTION
I had to make a few concessions when doing this.
Ideally I would have added this function under the `company` module,
but I chose to add it to the `name` module instead,
as the data happened to already exist in the locale files under
`name.title`.

However, I felt that the field names in the locale files were confusing,
so their wrappers in the name module are renamed for clarity.

For example, `faker.name.jobArea()` returns a random element from
locale.name.title.level. In my opinion, 'jobArea' was a much better
description of the data than 'level'.

Finally, fixed a bug in one unit test which didn't restore a function
to its original state after watching it.

fixes #148 