### PR TITLE
Added test to show that russian locale is broken

### DIFF
--- a/test/name.unit.js
+++ b/test/name.unit.js
@@ -6,6 +6,16 @@ if (typeof module !== 'undefined') {
 }
 
 describe("name.js", function () {
+
+    describe("firstNameLocale()", function () {
+        it("returns russian random name", function () {
+            var russian_first_names = faker.locales["ru"].name.male_first_name
+            faker.locale = "ru";
+            var first_name = faker.name.firstName();
+            assert.notEqual(russian_first_names.indexOf(first_name), -1, "Random russian name is wrong");
+        });
+    });
+
     describe("firstName()", function () {
         it("returns a random name", function () {
             sinon.stub(faker.name, 'firstName').returns('foo');


### PR DESCRIPTION
I'm not really pro in node testing... maybe I'm wrong, but as far as I understood 
```javascript
// test/name.unit.js
    sinon.stub(faker.name, 'firstName').returns('foo');
    var first_name = faker.name.firstName();

    assert.equal(first_name, 'foo');
```
You stub the result. i.e. in any case you'll get 'foo'. This test doesn't make sense for me. 

So I added new test just to demonstrate that loading of locales doesn't really work. 