### PR TITLE
Canadian zip codes (postal codes) now formatted properly. Better support for locale based zip code formats.

### DIFF
--- a/build/build/faker.js
+++ b/build/build/faker.js
@@ -18407,7 +18407,7 @@ en_CA.address = {
     "PE",
     "QC",
     "SK",
-    "YK"
+    "YT"
   ],
   "default_country": [
     "Canada"

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ exports.definitions = {};
 
 var _definitions = {
   "name": ["first_name", "last_name", "prefix", "suffix"],
-  "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "state", "state_abbr"],
+  "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "state", "state_abbr", "zipFormat"],
   "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb"],
   "lorem": ["words"],
   "hacker": ["abbreviation", "adjective", "noun", "verb", "ingverb"],

--- a/lib/address.js
+++ b/lib/address.js
@@ -2,8 +2,17 @@ var Helpers = require('./helpers');
 var faker = require('../index');
 
 var address = {
-    zipCode: function () {
-        return Helpers.replaceSymbolWithNumber(faker.random.array_element(["#####", '#####-####']));
+    zipCode: function (format) {
+		// if zip format is not specified, use the zip format defined for the locale
+		if (typeof format === 'undefined') {
+		    var localeFormat = faker.definitions.address.zipFormat;
+			if (typeof localeFormat === 'string') {
+				format = localeFormat;
+			} else {
+				format = faker.random.array_element(localeFormat);
+			}
+		}
+		return Helpers.replaceSymbols(format);
     },
 
     city: function () {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,6 +36,24 @@ exports.replaceSymbolWithNumber = function (string, symbol) {
     return str;
 };
 
+// parses string for symbols (numbers or letters) and replaces them appropriately
+exports.replaceSymbols = function (string) {
+    string = string || "";
+	var alpha = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']
+    var str = '';
+	
+    for (var i = 0; i < string.length; i++) {
+        if (string.charAt(i) == "#") {
+            str += faker.random.number(9);
+		} else if (string.charAt(i) == "?") {
+			str += alpha[Math.floor(Math.random() * alpha.length)];
+        } else {
+            str += string.charAt(i);
+        }
+    }
+    return str;
+};
+
 // takes an array and returns it randomized
 exports.shuffle = function (o) {
     o = o || ["a", "b", "c"];

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -3,6 +3,10 @@ module["exports"] = en;
 en.title = "English";
 en.separator = " & ";
 en.address = {
+  "zipFormat": [
+	"#####",
+	"#####-####"
+  ],
   "city_prefix": [
     "North",
     "East",

--- a/lib/locales/en_CA.js
+++ b/lib/locales/en_CA.js
@@ -34,7 +34,7 @@ en_CA.address = {
     "PE",
     "QC",
     "SK",
-    "YK"
+    "YT"
   ],
   "default_country": [
     "Canada"

--- a/lib/locales/en_CA.js
+++ b/lib/locales/en_CA.js
@@ -2,10 +2,7 @@ var en_CA = {};
 module["exports"] = en_CA;
 en_CA.title = "Canada (English)";
 en_CA.address = {
-  "postcode": [
-    "?#? #?#",
-    "?#?#?#"
-  ],
+  "zipFormat": "?#? #?#",
   "state": [
     "Alberta",
     "British Columbia",


### PR DESCRIPTION
The intent of this was to address issue #126. In doing so, I have allowed for zip code formats to be locale based. Also, a user can now pass in their desired zip code format like:

`faker.address.zipCode("####");`
`faker.address.zipCode("?#? #?#");`

If no format is passed in, faker simply uses the format defined by the locale. 

Also, YT is the official abbreviation for Yukon. Reference: http://en.wikipedia.org/wiki/ISO_3166-2:CA.