### PR TITLE
Fix random number unit test spec

### DIFF
--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -17,7 +17,7 @@ describe("random.js", function () {
 
     it("returns a random number given a maximum value as Object", function() {
       var options = { max: 10 };
-      assert.ok(faker.random.number(options) < options.max);
+      assert.ok(faker.random.number(options) <= options.max);
     });
 
     it("returns a random number between a range", function() {


### PR DESCRIPTION
Updated the "returns a random number given a maximum value as Object" to include the max value in the check (changed `<` to `<=`)

Previously, this test would randomly fail if the random number ended up being `10`.

Closes #185