### PR TITLE
replace broken shuffle algorithm with one from the internet

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,11 +36,31 @@ exports.replaceSymbolWithNumber = function (string, symbol) {
     return str;
 };
 
-// takes an array and returns it randomized
-exports.shuffle = function (o) {
-    o = o || ["a", "b", "c"];
-    for (var j, x, i = o.length; i; j = faker.random.number(i), x = o[--i], o[i] = o[j], o[j] = x);
-    return o;
+// takes an array and randomizes it in-place
+exports.shuffle = function (array) {
+
+    array = array || ["a", "b", "c"];
+
+    // taken from:
+    // http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+
+    var currentIndex = array.length, temporaryValue, randomIndex ;
+
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+
+        // Pick a remaining element...
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex -= 1;
+
+        // And swap it with the current element.
+        temporaryValue = array[currentIndex];
+        array[currentIndex] = array[randomIndex];
+        array[randomIndex] = temporaryValue;
+    }
+
+    return array;
+
 };
 
 exports.mustache = function (str, data) {


### PR DESCRIPTION
The shuffle algorithm was broken, and extremely hard to follow. I've replaced it with one I found on stackoverflow. This kind of thing is notoriously difficult to get right, so best to use a trusted implementation.

To demonstrate the problem, simply call the old shuffle many times. Eventually, all the items in the array are replaced with undefined.

for (var i = 0; i < 10000; i++) { console.log (faker.lorem.words ()); }