### PR TITLE
Update license property

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
     "sinon": "1.4.2",
     "vinyl-transform": "0.0.1"
   },
+  "license": "MIT",
   "main": "index.js"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/