### PR TITLE
Fix issue Marak/faker.js#214 with shuffle()

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,7 +39,7 @@ exports.replaceSymbolWithNumber = function (string, symbol) {
 // takes an array and returns it randomized
 exports.shuffle = function (o) {
     o = o || ["a", "b", "c"];
-    for (var j, x, i = o.length; i; j = faker.random.number(i), x = o[--i], o[i] = o[j], o[j] = x);
+    for (var j, x, i = o.length-1; i; j = faker.random.number(i), x = o[--i], o[i] = o[j], o[j] = x);
     return o;
 };
 

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -21,6 +21,16 @@ describe("helpers.js", function () {
         });
     });
 
+    describe("shuffle()", function () {
+        it("the output is the same length as the input", function () {
+            sinon.spy(faker.random, 'number');
+            var shuffled = faker.helpers.shuffle(["a", "b"]);
+            assert.ok(shuffled.length === 2);
+            assert.ok(faker.random.number.calledWith(1));
+            faker.random.number.restore();
+        });
+    });
+
     describe("slugify()", function () {
         it("removes unwanted characters from URI string", function () {
             assert.equal(faker.helpers.slugify("Aiden.Harªann"), "Aiden.Harann");


### PR DESCRIPTION
Fix issue Marak/faker.js#214 with shuffle() sometimes inserting `undefined` into the shuffled array. 

Add a dubious spec that just asserts the proper usage of `faker.random.number()`.