### PR TITLE
Fixing bug in random.number when max = 0

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -26,7 +26,7 @@ var random = {
 
         // Make the range inclusive of the max value
         var max = options.max;
-        if (max > 0) {
+        if (max >= 0) {
           max += options.precision;
         } 
           

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -24,6 +24,11 @@ describe("random.js", function () {
       assert.ok(faker.random.number(options) === 0);
     });
 
+    it("returns a random number given a negative number minimum and maximum value of 0", function() {
+      var options = { min: -100, max: 0 };
+      assert.ok(faker.random.number(options) <= options.max);
+    });
+
     it("returns a random number between a range", function() {
       var options = { min: 22, max: 33 };
       for(var i = 0; i < 100; i++) {

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -14,10 +14,14 @@ describe("random.js", function () {
       assert.ok(faker.random.number(max) <= max);
     });
 
-
     it("returns a random number given a maximum value as Object", function() {
       var options = { max: 10 };
       assert.ok(faker.random.number(options) <= options.max);
+    });
+
+    it("returns a random number given a maximum value of 0", function() {
+      var options = { max: 0 };
+      assert.ok(faker.random.number(options) === 0);
     });
 
     it("returns a random number between a range", function() {
@@ -59,6 +63,18 @@ describe("random.js", function () {
       
       assert.equal(opts.min, min);
       assert.equal(opts.max, max);
+    });
+  });
+
+  describe('array_element', function() {
+    it('returns a random element in the array', function() {
+      var testArray = ['hello', 'to', 'you', 'my', 'friend'];
+      assert.ok(testArray.indexOf(faker.random.array_element(testArray)) > -1);
+    });
+
+    it('returns a random element in the array when there is only 1', function() {
+      var testArray = ['hello'];
+      assert.ok(testArray.indexOf(faker.random.array_element(testArray)) > -1);
     });
   });
 


### PR DESCRIPTION
Also added tests for random.array_element

This fixes the same issue noted in [this pr](https://github.com/Marak/faker.js/pull/154)
However, it fixes it a different way.

I came across this issue initially when calling `faker.random.array_element` on an array of length 1.  Since the result of `faker.random.number({max:0})` was not being constrained correctly, the result of the aforementioned command would be `undefined`.