### PR TITLE
Adding a MAC Address generator

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -89,6 +89,17 @@ var internet = {
 
     },
 
+    mac: function(){
+        var i, mac = "";
+        for (i=0; i < 12; i++) {
+            mac+= parseInt(Math.random()*16).toString(16);
+            if (i%2==1 && i != 11) {
+                mac+=":";
+            }
+        }
+        return mac;
+    },
+
     password: function (len, memorable, pattern, prefix) {
       len = len || 15;
       if (typeof memorable === "undefined") {

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -133,7 +133,7 @@ describe("internet.js", function () {
         });
     });
 
-    describe("macAddess()", function () {
+    describe("mac()", function () {
         it("returns a random MAC address with 6 hexadecimal digits", function () {
             var mac = faker.internet.mac();
             assert.ok(mac.match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/));

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -132,4 +132,11 @@ describe("internet.js", function () {
             assert.ok(color.match(/^#[a-f0-9]{6}$/));
         });
     });
+
+    describe("macAddess()", function () {
+        it("returns a random MAC address with 6 hexadecimal digits", function () {
+            var mac = faker.internet.mac();
+            assert.ok(mac.match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/));
+        });
+    });
 });


### PR DESCRIPTION
`faker.internet.mac()` generate a valid MAC Address with a sequence of six pairs of hexadecimals numbers separated by `:`