### PR TITLE
Add name interpolation via helpers.template() function

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,6 +51,14 @@ exports.mustache = function (str, data) {
   return str;
 };
 
+exports.template = function (str, data) {
+  for(var p in data) {
+    var re = new RegExp('#{' + p + '}', 'g')
+    str = str.replace(re, data[p]);
+  }
+  return str;
+};
+
 exports.createCard = function () {
     return {
         "name": faker.name.findName(),
@@ -174,4 +182,3 @@ String.prototype.capitalize = function () { //v1.0
     });
 };
 */
-

--- a/lib/name.js
+++ b/lib/name.js
@@ -3,7 +3,11 @@ var faker = require('../index');
 var _name = {
 
     firstName: function () {
-      if (typeof faker.definitions.name.male_first_name !== "undefined" && typeof faker.definitions.name.female_first_name !== "undefined") {
+      if (typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.male_first_name !== "undefined"
+        && typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.female_first_name !== "undefined"
+      ) {
         // some locale datasets ( like ru ) have first_name split by gender. since the name.first_name field does not exist in these datasets,
         // we must randomly pick a name from either gender array so faker.name.firstName will return the correct locale data ( and not fallback )
         var rand = faker.random.number(1);
@@ -16,8 +20,29 @@ var _name = {
       return faker.random.array_element(faker.definitions.name.first_name);
     },
 
+    // basically a clone of firstName
+    middleName: function () {
+      if (typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.male_middle_name !== "undefined"
+        && typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.female_middle_name !== "undefined"
+      ) {
+        var rand = faker.random.number(1);
+        if (rand === 0) {
+          return faker.random.array_element(faker.locales[faker.locale].name.male_middle_name);
+        } else {
+          return faker.random.array_element(faker.locales[faker.locale].name.female_middle_name);
+        }
+      }
+      return faker.random.array_element(faker.definitions.name.middle_name);
+    },
+
     lastName: function () {
-      if (typeof faker.definitions.name.male_last_name !== "undefined" && typeof faker.defintions.name.female_last_name !== "undefined") {
+      if (typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.male_last_name !== "undefined"
+        && typeof faker.locales[faker.locale].name !== "undefined"
+        && typeof faker.locales[faker.locale].name.female_last_name !== "undefined"
+      ) {
         // some locale datasets ( like ru ) have last_name split by gender. i have no idea how last names can have genders, but also i do not speak russian
         // see above comment of firstName method
         var rand = faker.random.number(1);
@@ -31,17 +56,29 @@ var _name = {
     },
 
     findName: function (firstName, lastName) {
-        var r = faker.random.number(8);
         firstName = firstName || faker.name.firstName();
+        var middleName = faker.name.middleName();
         lastName = lastName || faker.name.lastName();
-        switch (r) {
-        case 0:
-            return faker.name.prefix() + " " + firstName + " " + lastName;
-        case 1:
-            return firstName + " " + lastName + " " + faker.name.suffix();
+        var nameFormat;
+        try {
+            nameFormat = faker.random.array_element(faker.locales[faker.locale].name.name);
+        } catch (e) {
+            // No name format found for given locale, going with default [en] name format
+            nameFormat = faker.random.array_element(faker.locales["en"].name.name);
         }
-
-        return firstName + " " + lastName;
+        var fullName = faker.helpers.template(nameFormat, {
+            first_name: firstName,
+            last_name: lastName,
+            male_first_name: firstName,
+            male_middle_name: middleName,
+            male_last_name: lastName,
+            female_first_name: firstName,
+            female_middle_name: middleName,
+            female_last_name: lastName,
+            prefix: faker.name.prefix(),
+            suffix: faker.name.suffix()
+        });
+        return fullName;
     },
 
     prefix: function () {

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -38,6 +38,22 @@ describe("helpers.js", function () {
         });
     });
 
+    describe("mustache()", function () {
+        it("interpolates mustache variables", function () {
+            var str = "{{foo}} {{foo}}";
+            var data = {"foo": "bar"};
+            assert.equal(faker.helpers.mustache(str, data), "bar bar");
+        });
+    });
+
+    describe("template()", function () {
+        it("interpolates template variables", function () {
+          var str = "#{foo} #{foo}";
+          var data = {"foo": "bar"};
+          assert.equal(faker.helpers.template(str, data), "bar bar");
+        });
+    });
+
     describe("createCard()", function () {
         it("returns an object", function () {
             var card = faker.helpers.createCard();

--- a/test/name.unit.js
+++ b/test/name.unit.js
@@ -17,6 +17,17 @@ describe("name.js", function () {
         });
     });
 
+    describe("middleName()", function () {
+        it("returns a random name", function () {
+            sinon.stub(faker.name, 'middleName').returns('foo');
+            var middle_name = faker.name.middleName();
+
+            assert.equal(middle_name, 'foo');
+
+            faker.name.middleName.restore();
+        });
+    });
+
     describe("lastName()", function () {
         it("returns a random name", function () {
             sinon.stub(faker.name, 'lastName').returns('foo');


### PR DESCRIPTION
helpers.template() works like mustache(), but checks for #{..} instead
of {{..}}.

Add support for middle_name and fixes "ru" locale which uses male and
female first, middle and last names.

Add unit test for both.