### PR TITLE
Create fr_CA.js

### DIFF
--- a/lib/locales.js
+++ b/lib/locales.js
@@ -13,6 +13,7 @@ exports['en_au_ocker'] = require('./locales/en_au_ocker.js');
 exports['es'] = require('./locales/es.js');
 exports['fa'] = require('./locales/fa.js');
 exports['fr'] = require('./locales/fr.js');
+exports['fr_CA'] = require('./locales/fr_CA.js');
 exports['ge'] = require('./locales/ge.js');
 exports['it'] = require('./locales/it.js');
 exports['ja'] = require('./locales/ja.js');

--- a/lib/locales/fr_CA.js
+++ b/lib/locales/fr_CA.js
@@ -1,0 +1,65 @@
+var fr_CA = {};
+module["exports"] = fr_CA;
+fr_CA.title = "Canada (French)";
+fr_CA.address = {
+  "postcode": [
+    "?#? #?#"
+  ],
+  "state": [
+    "Alberta",
+    "Colombie-Britannique",
+    "Manitoba",
+    "Nouveau-Brunswick",
+    "Terre-Neuve-et-Labrador",
+    "Nouvelle-Écosse",
+    "Territoires du Nord-Ouest",
+    "Nunavut",
+    "Ontario",
+    "Île-du-Prince-Édouard",
+    "Québec",
+    "Saskatchewan",
+    "Yukon"
+  ],
+  "state_abbr": [
+    "AB",
+    "BC",
+    "MB",
+    "NB",
+    "NL",
+    "NS",
+    "NU",
+    "NT",
+    "ON",
+    "PE",
+    "QC",
+    "SK",
+    "YK"
+  ],
+  "default_country": [
+    "Canada"
+  ]
+};
+fr_CA.internet = {
+  "free_email": [
+    "gmail.com",
+    "yahoo.ca",
+    "hotmail.com"
+  ],
+  "domain_suffix": [
+    "qc.ca",
+    "ca",
+    "com",
+    "biz",
+    "info",
+    "name",
+    "net",
+    "org"
+  ]
+};
+fr_CA.phone_number = {
+  "formats": [
+    "### ###-####",
+    "1 ### ###-####",
+    "### ###-####, poste ###"
+  ]
+};


### PR DESCRIPTION
fr_CA locale, adapted from en_CA

I translated the provinces and adjusted [postal code](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=5052) and [phone number](http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=3293) formats.