### PR TITLE
Username must be a string

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -28,7 +28,7 @@ var internet = {
             result = firstName + faker.random.array_element([".", "_"]) + lastName + faker.random.number(99);
             break;
         }
-        result = result.replace(/'/g, "");
+        result = result.toString().replace(/'/g, "");
         result = result.replace(/ /g, "");
         return result;
     },


### PR DESCRIPTION
Eliminate cases when result is a number, in which case, replace does not exist.