### PR TITLE
Fixed lorem.sentence formatting

### DIFF
--- a/lib/lorem.js
+++ b/lib/lorem.js
@@ -15,7 +15,8 @@ var Lorem = function (faker) {
       // strange issue with the node_min_test failing for captialize, please fix and add faker.lorem.back
       //return  faker.lorem.words(wordCount + Helpers.randomNumber(range)).join(' ').capitalize();
 
-      return  faker.lorem.words(wordCount + faker.random.number(range)).join(' ');
+      var sentence = faker.lorem.words(wordCount + faker.random.number(range)).join(' ');
+      return sentence.charAt(0).toUpperCase() + sentence.slice(1) + '.';
   };
 
   self.sentences = function (sentenceCount) {


### PR DESCRIPTION
Partially addresses https://github.com/Marak/faker.js/issues/233. Sentences now start with a capital letter and end with a period. 

```js
faker.lorem.sentence()
// "Voluptatibus rerum non possimus similique ut consectetur aut provident."
```

Held off on changing the return types of `lorem.sentences` and `lorem.paragraphs` since thats a breaking change.