### PR TITLE
through2 dependency added to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node-minify": "*",
     "optimist": "0.3.5",
     "sinon": "1.4.2",
-    "vinyl-transform": "0.0.1"
+    "vinyl-transform": "0.0.1",
+    "through2": "2.0.0"
   },
   "license": "MIT",
   "main": "index.js"


### PR DESCRIPTION
`through2` required by `buid/gulpfile.js` was missing.