### PR TITLE
Only append suffix to streetName if suffix is present

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -41,12 +41,17 @@ function Address (faker) {
 
   this.streetName = function () {
       var result;
+      var suffix = faker.address.streetSuffix();
+      if (suffix !== "") {
+          suffix = " " + suffix
+      }
+
       switch (faker.random.number(1)) {
       case 0:
-          result = faker.name.lastName() + " " + faker.address.streetSuffix();
+          result = faker.name.lastName() + suffix;
           break;
       case 1:
-          result = faker.name.firstName() + " " + faker.address.streetSuffix();
+          result = faker.name.firstName() + suffix;
           break;
       }
       return result;

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -73,7 +73,6 @@ describe("address.js", function () {
         });
 
         afterEach(function () {
-            faker.random.number.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
             faker.address.streetSuffix.restore();
@@ -87,6 +86,8 @@ describe("address.js", function () {
             assert.ok(!faker.name.firstName.called);
             assert.ok(faker.name.lastName.calledOnce);
             assert.ok(faker.address.streetSuffix.calledOnce);
+
+            faker.random.number.restore();
         });
 
         it("occasionally returns first name + suffix", function () {
@@ -98,6 +99,16 @@ describe("address.js", function () {
             assert.ok(faker.name.firstName.calledOnce);
             assert.ok(!faker.name.lastName.called);
             assert.ok(faker.address.streetSuffix.calledOnce);
+
+            faker.random.number.restore();
+        });
+
+        it("trims trailing whitespace from the name", function() {
+            faker.address.streetSuffix.restore();
+
+            sinon.stub(faker.address, 'streetSuffix').returns("")
+            var street_name = faker.address.streetName();
+            assert.ok(!street_name.match(/ $/));
         });
     });
 


### PR DESCRIPTION
When `streetSuffix()` returns an empty string, do not append a space to the end of the name part of `streetName()`. With the prior behavior, occasionally, `streetName()` would return something like `"Ashley "` (notice the trailing space), which is undesirable in many circumstances.