### PR TITLE
No space before citySuffix in city name

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -17,10 +17,10 @@ function Address (faker) {
 
   this.city = function (format) {
     var formats = [
-      '{{address.cityPrefix}} {{name.firstName}} {{address.citySuffix}}',
+      '{{address.cityPrefix}} {{name.firstName}}{{address.citySuffix}}',
       '{{address.cityPrefix}} {{name.firstName}}',
-      '{{name.firstName}} {{address.citySuffix}}',
-      '{{name.lastName}} {{address.citySuffix}}'
+      '{{name.firstName}}{{address.citySuffix}}',
+      '{{name.lastName}}{{address.citySuffix}}'
     ];
 
     if (typeof format !== "number") {


### PR DESCRIPTION
The citySuffix is a real word suffix (like "ton" or "burgh") so there should not be whitespace before it.

(The cityPrefix is a separate word (like "Lake" or "North"), so still needs whitespace.)