### PR TITLE
Implementation of support for domainWords() without apostrophes

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -3,6 +3,15 @@ var password_generator = require('../vendor/password-generator.js'),
 
 var Internet = function (faker) {
   var self = this;
+
+
+  self._nameCleaner = /([\\~#&*{}/:<>?|\"])/ig;
+  self.allowApostrophe = function(allow){
+    if (allow)
+      this._nameCleaner = /([\\~#&*{}/:<>?|\"])/ig;
+    else
+      this._nameCleaner = /([\\~#&*{}/:<>?|\"\'])/ig;
+  }
   self.avatar = function () {
       return faker.random.arrayElement(faker.definitions.internet.avatar_uri);
   };
@@ -50,7 +59,7 @@ var Internet = function (faker) {
   };
 
   self.domainWord = function () {
-      return faker.name.firstName().replace(/([\\~#&*{}/:<>?|\"])/ig, '').toLowerCase();
+      return faker.name.firstName().replace(this._nameCleaner, '').toLowerCase();
   };
 
   self.ip = function () {
@@ -106,7 +115,7 @@ var Internet = function (faker) {
     }
     return password_generator(len, memorable, pattern, prefix);
   }
-  
+
 };
 
 


### PR DESCRIPTION
Closes Marak/faker.js#283

This is just one way to implement but it retains the current behaviour unless a user calls faker.internet.allowApostrophe(false);
