### PR TITLE
Added Swedish locale for date

### DIFF
--- a/lib/locales/sv/date/index.js
+++ b/lib/locales/sv/date/index.js
@@ -1,0 +1,4 @@
+var date = {};
+module["exports"] = date;
+date.month = require("./month");
+date.weekday = require("./weekday");

--- a/lib/locales/sv/date/month.js
+++ b/lib/locales/sv/date/month.js
@@ -1,0 +1,31 @@
+// Source: http://unicode.org/cldr/trac/browser/tags/release-27/common/main/en.xml#L1799
+module["exports"] = {
+  wide: [
+    "januari",
+    "februari",
+    "mars",
+    "april",
+    "maj",
+    "juni",
+    "juli",
+    "augusti",
+    "september",
+    "oktober",
+    "november",
+    "december"
+  ],
+  abbr: [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "maj",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "okt",
+    "nov",
+    "dec"
+  ]
+};

--- a/lib/locales/sv/date/weekday.js
+++ b/lib/locales/sv/date/weekday.js
@@ -1,0 +1,21 @@
+// Source: http://unicode.org/cldr/trac/browser/tags/release-27/common/main/en.xml#L1847
+module["exports"] = {
+  wide: [
+    "söndag",
+    "måndag",
+    "tisdag",
+    "onsdag",
+    "torsdag",
+    "fredag",
+    "lördag"
+  ],
+  abbr: [
+    "sön",
+    "mån",
+    "tis",
+    "ons",
+    "tor",
+    "fre",
+    "lör"
+  ]
+};

--- a/lib/locales/sv/index.js
+++ b/lib/locales/sv/index.js
@@ -9,3 +9,4 @@ sv.phone_number = require("./phone_number");
 sv.cell_phone = require("./cell_phone");
 sv.commerce = require("./commerce");
 sv.team = require("./team");
+sv.date = require("./date");


### PR DESCRIPTION
Added support for Swedish months and weekdays, based on the english implementation.
I also excluded `wide_context` and `abbr_context` as they are optional according to the comments and there is no contextual difference in Swedish.