### PR TITLE
Remove `Math.random()` calls to utilize seed

### DIFF
--- a/lib/commerce.js
+++ b/lib/commerce.js
@@ -6,24 +6,7 @@ var Commerce = function (faker) {
   };
 
   self.department = function(max, fixedAmount) {
-    
       return faker.random.arrayElement(faker.definitions.commerce.department);
-      /*
-      max = max || 3;
-
-      var num = Math.floor((Math.random() * max) + 1);
-      if (fixedAmount) {
-          num = max;
-      }
-
-      var categories = faker.commerce.categories(num);
-
-      if(num > 1) {
-          return faker.commerce.mergeCategories(categories);
-      }
-
-      return categories[0];
-      */
   };
 
   self.productName = function() {
@@ -42,7 +25,9 @@ var Commerce = function (faker) {
           return symbol + 0.00;
       }
 
-      return symbol + (Math.round((Math.random() * (max - min) + min) * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
+      var randValue = faker.random.number({ max: max, min: min });
+
+      return symbol + (Math.round(randValue * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
   };
 
   /*

--- a/lib/finance.js
+++ b/lib/finance.js
@@ -56,8 +56,9 @@ var Finance = function (faker) {
       max = max || 1000;
       dec = dec || 2;
       symbol = symbol || '';
+      var randValue = faker.random.number({ max: max, min: min });
 
-      return symbol + (Math.round((Math.random() * (max - min) + min) * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
+      return symbol + (Math.round(randValue * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
 
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -43,7 +43,7 @@ var Helpers = function (faker) {
           if (string.charAt(i) == "#") {
               str += faker.random.number(9);
   		} else if (string.charAt(i) == "?") {
-  			str += alpha[Math.floor(Math.random() * alpha.length)];
+  			str += faker.random.arrayElement(alpha);
           } else {
               str += string.charAt(i);
           }
@@ -184,9 +184,9 @@ var Helpers = function (faker) {
       "account" : faker.finance.account()
     };
   };
-  
+
   return self;
-  
+
 };
 
 

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -91,7 +91,7 @@ var Internet = function (faker) {
   self.mac = function(){
       var i, mac = "";
       for (i=0; i < 12; i++) {
-          mac+= parseInt(Math.random()*16).toString(16);
+          mac+= faker.random.number(15).toString(16);
           if (i%2==1 && i != 11) {
               mac+=":";
           }
@@ -106,7 +106,7 @@ var Internet = function (faker) {
     }
     return password_generator(len, memorable, pattern, prefix);
   }
-  
+
 };
 
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -65,7 +65,7 @@ function Random (faker, seed) {
       var self = this;
       var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
       var replacePlaceholders = function (placeholder) {
-          var random = self.number(15);
+          var random = faker.random.number(15);
           var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
           return value.toString(16);
       };

--- a/lib/random.js
+++ b/lib/random.js
@@ -62,9 +62,10 @@ function Random (faker, seed) {
   }
 
   this.uuid = function () {
+      var self = this;
       var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
       var replacePlaceholders = function (placeholder) {
-          var random = Math.random()*16|0;
+          var random = self.number(15);
           var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
           return value.toString(16);
       };

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -74,6 +74,22 @@ describe("random.js", function () {
       faker.seed(100);
       var name = faker.name.findName();
       assert.equal(name, 'Dulce Jenkins');
+
+      [
+        faker.random.number,
+        faker.random.uuid,
+        faker.internet.mac
+      ]
+      .forEach(function(fn) {
+        faker.seed(100);
+        var a = fn();
+
+        faker.seed(100);
+        var b = fn();
+
+        assert.equal(a, b);
+      });
+
     })
   });
 


### PR DESCRIPTION
This PR removes all calls to `Math.random()` to ensure all generators are using the same seed utilized by `faker.random.number()`.