### PR TITLE
Add support for loading an external lib

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,4 +130,18 @@ Faker.prototype.seed = function(value) {
   this.seedValue = value;
   this.random = new Random(this, this.seedValue);
 }
+
+Faker.prototype.load = function(_path) {
+  var fs = require('fs');
+  var path = require('path');
+  
+  var items = fs.readdirSync(_path);
+
+  for (var i=0; i<items.length; i++) {
+    var filename = items[i];
+    var module = path.basename(filename, '.js');
+    this[module] = require(_path + '/' + filename)(this);
+  }
+};
+
 module['exports'] = Faker;

--- a/test/all.functional.js
+++ b/test/all.functional.js
@@ -44,3 +44,8 @@ describe("functional tests", function () {
     }
 
 });
+
+describe("load modules", function() {
+  faker.load(__dirname + '/test_lib')
+  assert.ok(faker.test.meaning_of_life() == 42);
+});

--- a/test/test_lib/test.js
+++ b/test/test_lib/test.js
@@ -1,0 +1,11 @@
+var TestModule = function (faker) {
+  var self = this;
+  
+  self.meaning_of_life = function () {
+    return 42;
+  };
+
+  return self;
+};
+
+module['exports'] = TestModule;


### PR DESCRIPTION
This PR adds the ability to easily load custom modules, once the faker object has been instantiated, using the following syntax:
```
var faker = require('faker')
faker.load('/absolute/path/for/external/modules')
```

Based on feature request https://github.com/Marak/faker.js/issues/319