### PR TITLE
Export factory method for new Faker instances, for non-global use (#318)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 // since we are requiring the top level of faker, load all locales by default
 var Faker = require('./lib');
-var faker = new Faker({ locales: require('./lib/locales') });
+
+function makeNewInstance() {
+  return new Faker({ locales: require('./lib/locales') });
+}
+
+var faker = makeNewInstance();
+faker.makeNewInstance = makeNewInstance;
 module['exports'] = faker;

--- a/test/all.functional.js
+++ b/test/all.functional.js
@@ -34,8 +34,15 @@ describe("functional tests", function () {
       Object.keys(modules).forEach(function (module) {
           describe(module, function () {
               modules[module].forEach(function (meth) {
-                  it(meth + "()", function () {
+                  var localFaker = faker.makeNewInstance();
+
+                  it(meth + "() (global instance)", function () {
                       var result = faker[module][meth]();
+                      assert.ok(result);
+                  });
+
+                  it(meth + "() (local instance)", function () {
+                      var result = localFaker[module][meth]();
                       assert.ok(result);
                   });
               });


### PR DESCRIPTION
`makeNewInstance()` creates an instance identical to the faker global (same locale data) but mutable state is not shared (e.g. seed value).