### PR TITLE
Fix 'this' reference in exampleEmail

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -40,7 +40,7 @@ var Internet = function (faker) {
   };
   self.exampleEmail = function (firstName, lastName) {
       var provider = faker.random.arrayElement(faker.definitions.internet.example_email);
-      return this.email(firstName, lastName, provider);
+      return self.email(firstName, lastName, provider);
   };
 
   self.userName = function (firstName, lastName) {


### PR DESCRIPTION
This fixes an issue when using exampleEmail in a fake template (e.g. {{name.exampleEmail}}).