### PR TITLE
Fix typo in docstring

### DIFF
--- a/lib/lorem.js
+++ b/lib/lorem.js
@@ -83,7 +83,7 @@ var Lorem = function (faker) {
    *
    * @method faker.lorem.paragraphs
    * @param {number} paragraphCount defaults to 3
-   * @param {string} separatora defaults to `'\n \r'`
+   * @param {string} separator defaults to `'\n \r'`
    */
   self.paragraphs = function (paragraphCount, separator) {
     if (typeof separator === "undefined") {


### PR DESCRIPTION
Fix typo in docstring for lorem.js. (separatora vs separator)