### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,13 @@
   },
   "license": "MIT",
   "main": "index.js",
-  "dependencies": {}
+  "dependencies": {},
+  "files": [
+    "index.js",
+    "locale",
+    "vendor",
+    "lib",
+    "Readme.md",
+    "MIT-LICENSE.txt"
+  ]
 }


### PR DESCRIPTION
Currently Faker publishes the following files/folders to NPM:

```
   17.7 MiB [##########] /examples                                                                                           
   17.4 MiB [######### ] /build
    4.3 MiB [##        ] /lib
  312.0 KiB [          ] /test
  140.0 KiB [          ] /locale
   56.0 KiB [          ]  logo.png
   28.0 KiB [          ] /vendor
   12.0 KiB [          ] /.npm
    8.0 KiB [          ]  Readme.md
    8.0 KiB [          ] /meteor
    4.0 KiB [          ]  .jshintrc
    4.0 KiB [          ]  migrate.js
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  CHANGELOG.md
    4.0 KiB [          ]  MIT-LICENSE.txt
    4.0 KiB [          ]  CONTRIBUTING.md
    4.0 KiB [          ]  package.js
    4.0 KiB [          ]  Makefile
    4.0 KiB [          ]  bower.json
    4.0 KiB [          ]  .travis.yml
    4.0 KiB [          ]  index.js
    4.0 KiB [          ]  .npmignore
    4.0 KiB [          ]  lazy.js
    4.0 KiB [          ]  .jshintignore
```

This PR limits the files uploaded when publishing, which should bring down the size significantly. The `files` section of package.json is a whitelist of the files and folders that will be included.

https://docs.npmjs.com/files/package.json#files

Cheers! :beers: 
