### PR TITLE
Generate by locale definitions

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -284,7 +284,6 @@ var Helpers = function (faker) {
   self.generateBy = function(def, path) {
     var arr = getProp(def, path.toLowerCase());
     var item;
-    debugger;
     if (typeof(arr) == "string")
       item = arr;
     else if (arr && arr.length > 0)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -242,6 +242,70 @@ var Helpers = function (faker) {
     };
   };
 
+  function stringToPath(string) {
+    /** Used to match property names within property paths. */
+    var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]/g;
+
+    /** Used to match backslashes in property paths. */
+    var reEscapeChar = /\\(\\)?/g;    
+
+    var result = [];
+    string.replace(rePropName, function(match, number, quote, string) {
+      result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
+    });
+    return result;
+  };  
+
+  function getProp(object, path) {
+    if (object != null && typeof(path) == "string" && path in Object(object))
+      path = [path];
+    else
+      path = stringToPath(path);
+
+    var index = 0,
+        length = path.length;
+
+    while (object != null && index < length) {
+      object = object[path[index++]];
+    }
+    return (index && index == length) ? object : undefined;
+  };
+
+  /**
+   * Generate fake data by locale formats
+   * @param {string} path 
+   * @method faker.helpers.generate
+   */
+  self.generate = function(path) {
+    var locale = faker.locales[faker.locale];
+    return self.generateBy(locale, path);
+  };
+
+  self.generateBy = function(def, path) {
+    var arr = getProp(def, path.toLowerCase());
+    if (arr && arr.length > 0)
+    {
+      var item = faker.random.arrayElement(arr);
+      if (item.indexOf("#{") != -1) {
+        item = item.replace(/\#\{([A-Za-z_\.]+)\}/g, function(match, cap) {
+          if (cap.indexOf(".") != -1)
+            return self.generateBy(def, cap);
+          else {
+            var newPath = cap;
+            var parts = path.split(".");
+            if (parts.length > 1) {
+              parts.pop();
+              newPath = parts.join(".") + "." + cap;
+            }
+            return self.generateBy(def, newPath);
+          }
+        });
+      }
+      item = self.replaceSymbols(item);
+      return item;
+    }
+  };  
+
   return self;
 
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -283,9 +283,14 @@ var Helpers = function (faker) {
 
   self.generateBy = function(def, path) {
     var arr = getProp(def, path.toLowerCase());
-    if (arr && arr.length > 0)
-    {
-      var item = faker.random.arrayElement(arr);
+    var item;
+    debugger;
+    if (typeof(arr) == "string")
+      item = arr;
+    else if (arr && arr.length > 0)
+      item = faker.random.arrayElement(arr);
+
+    if (item) {
       if (item.indexOf("#{") != -1) {
         item = item.replace(/\#\{([A-Za-z_\.]+)\}/g, function(match, cap) {
           if (cap.indexOf(".") != -1)

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -89,6 +89,10 @@ describe("helpers.js", function () {
             assert.equal(faker.helpers.generate("address.city"), "Marcusburgh");
         });
 
+        it("return a generated city name by index", function() {
+            assert.equal(faker.helpers.generate("address.city[1]"), "South Marcus");
+        });
+
         it("return a generated street address", function() {
             assert.equal(faker.helpers.generate("address.street_address"), "244 Sporer Curve");
         });

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -74,4 +74,28 @@ describe("helpers.js", function () {
       assert.ok(transaction.account);
     });
   });
+
+    describe("generate()", function() {
+        beforeEach(function() {
+            faker.locale = "en";
+            faker.seed(100);
+        })
+
+        it("return a generated full name", function() {
+            assert.equal(faker.helpers.generate("name.name"), "Marcus Gorczany");
+        });
+
+        it("return a generated city name", function() {
+            assert.equal(faker.helpers.generate("address.city"), "Marcusburgh");
+        });
+
+        it("return a generated street address", function() {
+            assert.equal(faker.helpers.generate("address.street_address"), "244 Sporer Curve");
+        });
+
+        it("return a generated company name", function() {
+            assert.equal(faker.helpers.generate("company.name"), "Osinski-Gorczany");
+        });
+    });
+
 });


### PR DESCRIPTION
Hi @Marak,

when I created the hungarian locale files, I found a problem, that Faker doesn't use format definitions in the locale files. I found many issues about it: #133 #232 #337 #339 

So I made a generate method in the helpers.js, that can solve recursively the locale formats #{...} variables. 

If you need a locale formatted company name use the `faker.helpers.generate("company.name")`. It will use the `company/name.js`, select a random item, and solve the variables. If found e.g. `#{Name.last_name}`, it will use the `name/last_name.js` and select an item...etc while solve every variables.

Examples:

Generate a name by locale formats:

```
faker.helpers.generate("name.name");
```

Generate a street address by locale formats:

```
faker.helpers.generate("address.street_address");
```

Generate a city name by locale formats:

```
faker.helpers.generate("address.city");
```

Generate a company name by locale formats:

```
faker.helpers.generate("company.name");
```

If you think it is useful, merge this PR :)
