### PR TITLE
[fix] Faker.fake("{{random.uuid}}") throws error in version 3.1

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -90,7 +90,7 @@ function Random (faker, seed) {
       var self = this;
       var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
       var replacePlaceholders = function (placeholder) {
-          var random = self.number({ min: 0, max: 15 });
+          var random = faker.random.number({ min: 0, max: 15 });
           var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
           return value.toString(16);
       };


### PR DESCRIPTION
Fix for https://github.com/Marak/faker.js/issues/368

No other Faker.fake("{{random.X}}") values had this issue.
