### PR TITLE
Fix output of faker.finance.amount.

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -88,9 +88,9 @@ var Finance = function (faker) {
       max = max || 1000;
       dec = dec || 2;
       symbol = symbol || '';
-      var randValue = faker.random.number({ max: max, min: min });
+      var randValue = faker.random.number({ max: max, min: min, precision: Math.pow(10, -dec) });
 
-      return symbol + (Math.round(randValue * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
+      return symbol + randValue.toFixed(dec);
 
   }
 


### PR DESCRIPTION
This simplifies the faker.finance.amount function a bit by avoiding arithmetic, and allows faker.random.number to do the heavy lifting with a precision operator. Fixes #361 