### PR TITLE
Fix random.uuid() to fallback to faker random num

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -90,7 +90,8 @@ function Random (faker, seed) {
       var self = this;
       var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
       var replacePlaceholders = function (placeholder) {
-          var random = self.number({ min: 0, max: 15 });
+          // seeded compatible random number call with faker fallback
+          var random = (self.number || faker.random.number)({ min: 0, max: 15 });
           var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
           return value.toString(16);
       };


### PR DESCRIPTION
This should close both #368 & #335 by allowing the uuid to be able to be called both directly and in the `Faker.fake` context.
