### PR TITLE
Allow user to specify separator to be used in mac address

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -282,11 +282,20 @@ var Internet = function (faker) {
    * @method faker.internet.mac
    */
   self.mac = function(sep){
-      var i, mac = "";
+      var i, 
+        mac = "",
+        validSep = ':';
+
+      // if the client passed in a different separator than `:`, 
+      // we will use it if it is in the list of acceptable separators (dash or no separator)
+      if (['-', ''].indexOf(sep) !== -1) {
+        validSep = sep;
+      } 
+
       for (i=0; i < 12; i++) {
           mac+= faker.random.number(15).toString(16);
           if (i%2==1 && i != 11) {
-              mac+=sep || ":";
+              mac+=validSep;
           }
       }
       return mac;

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -280,6 +280,7 @@ var Internet = function (faker) {
    * mac
    *
    * @method faker.internet.mac
+   * @param {string} sep
    */
   self.mac = function(sep){
       var i, 

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -281,12 +281,12 @@ var Internet = function (faker) {
    *
    * @method faker.internet.mac
    */
-  self.mac = function(){
+  self.mac = function(sep){
       var i, mac = "";
       for (i=0; i < 12; i++) {
           mac+= faker.random.number(15).toString(16);
           if (i%2==1 && i != 11) {
-              mac+=":";
+              mac+=sep || ":";
           }
       }
       return mac;

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -165,5 +165,23 @@ describe("internet.js", function () {
             var mac = faker.internet.mac();
             assert.ok(mac.match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/));
         });
+
+        it("uses the dash separator if we pass it in as our separator", function () {
+            var mac = faker.internet.mac('-');
+            assert.ok(mac.match(/^([a-f0-9]{2}-){5}[a-f0-9]{2}$/));
+        });
+
+        it("uses no separator if we pass in an empty string", function() {
+            var mac = faker.internet.mac('');
+            assert.ok(mac.match(/^[a-f0-9]{12}$/));
+        });
+
+        it("uses the default colon (:) if we provide an unacceptable separator", function() {
+            var mac = faker.internet.mac('!');
+            assert.ok(mac.match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/));
+
+            mac = faker.internet.mac('&');
+            assert.ok(mac.match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/));
+        });
     });
 });


### PR DESCRIPTION
A mac address can be of the following forms:

```
000CF15698AD
00:0C:F1:56:98:AD
00-0C-F1-56-98-AD
```

In my use case, I need to use `-`. 

I would like to add a `sep` parameter to allow the user to specify the mac separator. It will default to using `:` if none is provided.

I can add tests to this pull request, but wanted to validate if this approach works for you before I spend too much time on it.
