### PR TITLE
Fix case where root would be undefined

### DIFF
--- a/vendor/password-generator.js
+++ b/vendor/password-generator.js
@@ -62,4 +62,4 @@
   }
 
   // Establish the root object, `window` in the browser, or `global` on the server.
-}(this));
+}(typeof window === 'undefined' ? global : window));


### PR DESCRIPTION
In rare cases, I've found `this` to be undefined when trying to use this module. I think it's somehow related to webpack in eval mode, but can't quite figure it out. This PR stops it from crashing when trying to access properties on `undefined`.
