### PR TITLE
Fixing spaces in method

### DIFF
--- a/lib/fake.js
+++ b/lib/fake.js
@@ -32,23 +32,15 @@ function Fake (faker) {
       return res;
     }
 
-    // find first matching {{ and }}
-    var start = str.search('{{');
-    var end = str.search('}}');
+    var methodMatch = str.match(/{{(.*?)}}/);
 
     // if no {{ and }} is found, we are done
-    if (start === -1 && end === -1) {
+    if (!methodMatch) {
       return str;
     }
 
-    // console.log('attempting to parse', str);
-
-    // extract method name from between the {{ }} that we found
-    // for example: {{name.firstName}}
-    var token = str.substr(start + 2,  end - start - 2);
-    var method = token.replace('}}', '').replace('{{', '');
-
-    // console.log('method', method)
+    var matchedStr = methodMatch[0],
+      method = methodMatch[1].trim(); 
 
     // extract method parameters
     var regExp = /\(([^)]+)\)/;
@@ -94,7 +86,7 @@ function Fake (faker) {
     }
 
     // replace the found tag with the returned fake value
-    res = str.replace('{{' + token + '}}', result);
+    res = str.replace(matchedStr, result);
 
     // return the response recursively until we are done finding all tags
     return fake(res);    

--- a/test/fake.unit.js
+++ b/test/fake.unit.js
@@ -11,6 +11,16 @@ describe("fake.js", function () {
             assert.ok(name.match(/\d/));
         });
 
+        it("works with spaces", function() {
+            var name = faker.fake('{{ phone.phoneNumber }}');
+            assert.ok(name.match(/\d/));
+        });
+
+        it("works with multiple spaces", function() {
+            var name = faker.fake('{{      phone.phoneNumber      }}');
+            assert.ok(name.match(/\d/));
+        });
+
         it("replaces multiple tokens with random values for methods with no parameters", function () {
             var name = faker.fake('{{helpers.randomize}}{{helpers.randomize}}{{helpers.randomize}}');
             assert.ok(name.match(/[abc]{3}/));


### PR DESCRIPTION
As a first time user of faker, I wrote something akin to the following:

``` js
faker.fake('{{ name.lastName }}, {{ name.firstName }} {{ name.suffix }}');
```

And it failed with the following error:

```
Error: Invalid module: name
```

It took me awhile to realize that the problem was due to the spaces between `{{` and `name`. 

It's not a big deal _once you know it_, but it does make the learning curve a bit harder for new users. Spaces in brackets seems totally reasonable, and we should handle this case. This pull request does that.
