### PR TITLE
#420 Added dataurl method

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -192,7 +192,19 @@ var Image = function (faker) {
    */
   self.transport = function (width, height, randomize) {
     return faker.image.imageUrl(width, height, 'transport', randomize);
-  }  
+  };
+  /**
+   * dataurl
+   *
+   * @param {number} width
+   * @param {number} height
+   * @method faker.image.dataurl
+   */
+  self.dataurl = function (width, height) {
+    var rawPrefix = 'data:image/svg+xml;charset=UTF-8,';
+    var svgString = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="full" width="' + width + '" height="' + height + '"> <rect width="100%" height="100%" fill="grey"/>  <text x="0" y="20" font-size="20" text-anchor="start" fill="white">' + width + 'x' + height + '</text> </svg>';
+    return rawPrefix + encodeURIComponent(svgString);
+  };
 }
 
 module["exports"] = Image;

--- a/test/image.unit.js
+++ b/test/image.unit.js
@@ -113,4 +113,10 @@ describe("image.js", function () {
             assert.equal(transport, 'http://lorempixel.com/640/480/transport');
         });
     });
+    describe("dataurl", function () {
+        it("returns a blank data", function () {
+            var dataurl = faker.image.dataurl(200,300);
+            assert.equal(dataurl, 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20baseProfile%3D%22full%22%20width%3D%22200%22%20height%3D%22300%22%3E%20%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22grey%22%2F%3E%20%20%3Ctext%20x%3D%220%22%20y%3D%2220%22%20font-size%3D%2220%22%20text-anchor%3D%22start%22%20fill%3D%22white%22%3E200x300%3C%2Ftext%3E%20%3C%2Fsvg%3E');
+        });
+    });
 });


### PR DESCRIPTION
Adds `dataurl(width,height)` method that generates a dataurl embeded SVG image like this : 
![generated image](https://cloud.githubusercontent.com/assets/452941/19091233/0c2628f6-8a82-11e6-96ae-99172cd99264.png)

fixes #420
