### PR TITLE
Add .npmignore to reduce size of package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.npm/
+build/
+doc/
+examples/
+meteor/
+test/
+logo.png


### PR DESCRIPTION
In our company we use Docker containers for development. Once I checked size of Images and was amazed how 2 different Node application have 300 MB diff size. After some digging I found it is just in npm packages. One of then is this Faker.js

When checking size after npm install it give me this: 
```
du -hd0 node_modules/faker
74M    node_modules/faker
```

I decided to give it some time and check what can take so much I came with this. Adding `.npmignore` wont publish selected files to npm repository. It have many bonuses like saving network footprint to faster installation.

After adding `.npmignore` result is following:
```
du -hd0 node_modules/faker
9.3M    node_modules/faker
```

I tried to run tests on https://github.com/apiaryio/dredd which use this package and it works fine.

Of coure I dont know lot about this package, but I followed common sense and remove what deserves it :)

Give me hint if it is OK, should I add something or remove something more?

PS: there is how to test it https://docs.npmjs.com/misc/developers#before-publishing-make-sure-your-package-installs-and-works