### PR TITLE
Don't allow path seperators in generated filenames

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -19,6 +19,7 @@ function System (faker) {
     str = str.replace(/\,/g, '_');
     str = str.replace(/\-/g, '_');
     str = str.replace(/\\/g, '_');
+    str = str.replace(/\//g, '_');
     str = str.toLowerCase();
     return str;
   };
@@ -36,6 +37,7 @@ function System (faker) {
     str = str.replace(/\,/g, '_');
     str = str.replace(/\-/g, '_');
     str = str.replace(/\\/g, '_');
+    str = str.replace(/\//g, '_');
     str = str.toLowerCase();
     return str;
   };

--- a/test/system.unit.js
+++ b/test/system.unit.js
@@ -1,0 +1,27 @@
+if (typeof module !== 'undefined') {
+    var assert = require('assert');
+    var sinon = require('sinon');
+    var faker = require('../index');
+}
+
+describe("system.js", function () {
+    describe("fileName()", function () {
+        it("returns filenames without system path seperators", function () {
+            sinon.stub(faker.random, 'words').returns('24/7');
+            var fileName = faker.system.fileName();
+            assert.equal(fileName.indexOf('/'), -1, 'generated fileNames should not have path seperators');
+
+            faker.random.words.restore();
+        });
+    });
+
+    describe("commonFileName()", function () {
+        it("returns filenames without system path seperators", function () {
+            sinon.stub(faker.random, 'words').returns('24/7');
+            var fileName = faker.system.commonFileName();
+            assert.equal(fileName.indexOf('/'), -1, 'generated commonFileNames should not have path seperators');
+
+            faker.random.words.restore();
+        });
+    });
+});


### PR DESCRIPTION
A number of the word lists contain "24/7" as a word, for example: https://github.com/Marak/faker.js/blob/e8231413cc38a3ce49d712823dadbffbd1849acc/lib/locales/en/company/bs_adjective.js#L17

This means that calling `faker.system.fileName()` or `faker.system.commonFileName()` could sometimes yield something like "some_words_24/7_yep.jpg". This implies a file called "7_yep.jpg" in a directory called "some_words_24", which is probably not what someone calling these methods wants.