### PR TITLE
adds optional `exclude` parameter to .words()

### DIFF
--- a/lib/lorem.js
+++ b/lib/lorem.js
@@ -23,11 +23,21 @@ var Lorem = function (faker) {
    * @method faker.lorem.words
    * @param {number} num number of words, defaults to 3
    */
-  self.words = function (num) {
+  self.words = function (num, excludeList) {
       if (typeof num == 'undefined') { num = 3; }
+      if (!Array.isArray(excludeList)) { excludeList = []; }
+      var exclude = excludeList.reduce(function (excluded, wordToExclude) {
+        excluded[wordToExclude] = true;
+        return excluded;
+      }, {});
       var words = [];
+      var getNextWord = function () {
+        var nextWord = faker.lorem.word();
+        if (exclude[nextWord]) { return getNextWord(); }
+        return nextWord;
+      };
       for (var i = 0; i < num; i++) {
-        words.push(faker.lorem.word());
+        words.push(getNextWord());
       }
       return words.join(' ');
   };

--- a/test/lorem.unit.js
+++ b/test/lorem.unit.js
@@ -32,6 +32,20 @@ describe("lorem.js", function () {
                 assert.equal(words.length, 7);
             });
         });
+
+        context("when 'exclude' param passed in'", function () {
+          it("excludes the requested words", function () {
+            var exclude = faker.definitions.lorem.words.slice(1);
+            assert.ok(Array.isArray(exclude));
+            var str = faker.lorem.words(2, exclude);
+            assert.ok(str);
+            var words = str.split(' ');
+            assert.ok(Array.isArray(words));
+            assert.equal(words.length, 2);
+            assert.equal(words[0], faker.definitions.lorem.words[0]);
+            assert.equal(words[1], faker.definitions.lorem.words[0]);
+          });
+        });
     });
 
     describe("slug()", function () {
@@ -107,7 +121,7 @@ describe("lorem.js", function () {
                 assert.ok(typeof sentence === 'string');
                 var parts = sentence.split(' ');
                 assert.equal(parts.length, 14); // requested 10 plus stubbed 4.
-                assert.ok(faker.random.number.calledWith(4)); // random.number should be called with the 'range' we passed. 
+                assert.ok(faker.random.number.calledWith(4)); // random.number should be called with the 'range' we passed.
                 assert.ok(faker.lorem.words.calledWith(14));
 
                 faker.lorem.words.restore();
@@ -183,7 +197,7 @@ describe("lorem.js", function () {
         });
     });
     */
-    
+
     /*
 
     describe("paragraphs()", function () {


### PR DESCRIPTION
This resolves #449 by allowing the user to pass an optional second parameter to `.words`, an array of words to exclude from the output. When a word is selected by the`.word()` call, it will check to see if the word is part of the blacklist (which is first packaged into an object to avoid repeatedly iterating over an array), and if so will select another word until an allowed one is produced.
