### PR TITLE
Add 'setLocale' method to solve problem with ES6 import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,6 +238,8 @@ Setting a new locale is simple:
 
 ```js
 // sets locale to de
+faker.setLocale("de");
+// or
 faker.locale = "de";
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,10 @@ function Faker (opts) {
 
 };
 
+Faker.prototype.setLocale = function (locale) {
+  this.locale = locale;
+}
+
 Faker.prototype.seed = function(value) {
   var Random = require('./random');
   this.seedValue = value;


### PR DESCRIPTION
If you do `import * as faker from 'faker'` you can't do `faker.locale = 'uk';` since it produce runtime errors. 

ES6 forbids you to modify properties of top-level important objects and same is also true for TypeScrips. 