### PR TITLE
Remove emdash from pl's first_name.js

### DIFF
--- a/lib/locales/pl/name/first_name.js
+++ b/lib/locales/pl/name/first_name.js
@@ -249,7 +249,6 @@ module["exports"] = [
   "Angelina",
   "Anna",
   "Hanna",
-  "—",
   "Antonina",
   "Ariadna",
   "Aurora",


### PR DESCRIPTION
I think this em-dash was separating the male and female names?  Its definitely not a good first name to suggest.  (I noticed when faker.internet.domainWord() returned this em-dash.)