### PR TITLE
Update Random to create a per-instance copy of the RNG

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -5,15 +5,27 @@ var mersenne = require('../vendor/mersenne');
  * @namespace faker.random
  */
 function Random (faker, seed) {
+  var gen = new mersenne.MersenneTwister19937();
+
   // Use a user provided seed if it exists
   if (seed) {
     if (Array.isArray(seed) && seed.length) {
-      mersenne.seed_array(seed);
+      gen.init_by_array(seed);
     }
     else {
-      mersenne.seed(seed);
+      gen.init_genrand(seed);
     }
   }
+
+  // Copied from the marsenne package for compatibility.
+  function rand(max, min) {
+    if (max === undefined) {
+      min = 0;
+      max = 32768;
+    }
+    return Math.floor(gen.genrand_real2() * (max - min) + min);
+  }
+
   /**
    * returns a single random number based on a max number or range
    *
@@ -48,7 +60,7 @@ function Random (faker, seed) {
     }
 
     var randomNumber = Math.floor(
-      mersenne.rand(max / options.precision, options.min / options.precision));
+      rand(max / options.precision, options.min / options.precision));
     // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
     randomNumber = randomNumber / (1 / options.precision);
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -7,14 +7,22 @@ var mersenne = require('../vendor/mersenne');
 function Random (faker, seed) {
   var gen = new mersenne.MersenneTwister19937();
 
-  // Use a user provided seed if it exists
-  if (seed) {
-    if (Array.isArray(seed) && seed.length) {
-      gen.init_by_array(seed);
-    }
-    else {
-      gen.init_genrand(seed);
-    }
+  // Preserve past behavior and fall back to the default time-based seed if an
+  // empty array is passed.
+  if (Array.isArray(seed) && !seed.length) {
+    seed = undefined;
+  }
+
+  if (seed === undefined) {
+    // Default seed copied from the marsenne package for compatibility.
+    seed = (new Date).getTime() % 1000000000;
+  }
+
+  if (Array.isArray(seed)) {
+    gen.init_by_array(seed);
+  }
+  else {
+    gen.init_genrand(seed);
   }
 
   // Copied from the marsenne package for compatibility.

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -203,6 +203,19 @@ describe("random.js", function () {
       assert.equal(faker1.random.number(), faker2.random.number());
     })
 
+    it('has different default seeds across invocations', function (done) {
+      var faker1 = new Faker();
+
+      // Execute the rest of the test after a short delay, so the second
+      // instance gets a different random seed.
+      setTimeout(function() {
+        var faker2 = new Faker();
+
+        assert.notEqual(faker1.random.number(), faker2.random.number());
+        done();
+      }, 1);
+    })
+
   })
 
 });

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -3,6 +3,7 @@ if (typeof module !== 'undefined') {
     var sinon = require('sinon');
     var _ = require('lodash');
     var faker = require('../index');
+    var Faker = require('../lib');
 }
 
 
@@ -189,4 +190,19 @@ describe("random.js", function () {
       assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
     })
   })
+
+  describe('independent', function() {
+
+    it('generates independent sequences', function () {
+      var faker1 = new Faker();
+      faker1.seed(1);
+
+      var faker2 = new Faker();
+      faker2.seed(1);
+
+      assert.equal(faker1.random.number(), faker2.random.number());
+    })
+
+  })
+
 });


### PR DESCRIPTION
Before this change, it appeared that multiple, independent Faker
instances were legal.  But, when multiple instances were created, their
shared random number generators would overwrite each others' states.

After this change, each Random instance (and therefore each Faker
instance) has its own copy of the random number generator, ensuring that
calls to one Faker instance do not affect the stream of values generated
by another.