### PR TITLE
[api] Add method `faker.random.float`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 [![npm version](https://badge.fury.io/js/faker.svg)](http://badge.fury.io/js/faker)
 
-[![OpenCollective](https://opencollective.com/fakerjs/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/fakerjs/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/fakerjs/sponsors/badge.svg)](#sponsors)
 
 ## Demo
@@ -206,6 +206,7 @@ This will interpolate the format string with the value of methods `name.lastName
   * phoneFormats
 * random
   * number
+  * float
   * arrayElement
   * objectElement
   * uuid
@@ -282,7 +283,7 @@ faker.locale = "de";
 
 ### Individual Localization Packages
 
-As of vesion `v3.0.0` faker.js supports incremental loading of locales. 
+As of vesion `v3.0.0` faker.js supports incremental loading of locales.
 
 By default, requiring `faker` will include *all* locale data.
 
@@ -470,4 +471,3 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 <a href="https://opencollective.com/fakerjs/sponsor/27/website" target="_blank"><img src="https://opencollective.com/fakerjs/sponsor/27/avatar.svg"></a>
 <a href="https://opencollective.com/fakerjs/sponsor/28/website" target="_blank"><img src="https://opencollective.com/fakerjs/sponsor/28/avatar.svg"></a>
 <a href="https://opencollective.com/fakerjs/sponsor/29/website" target="_blank"><img src="https://opencollective.com/fakerjs/sponsor/29/avatar.svg"></a>
-

--- a/lib/random.js
+++ b/lib/random.js
@@ -57,6 +57,26 @@ function Random (faker, seed) {
   }
 
   /**
+   * returns a single random floating-point number based on a max number or range
+   *
+   * @method faker.random.float
+   * @param {mixed} options
+   */
+  this.float = function (options) {
+      if (typeof options === "number") {
+        options = {
+          precision: options
+        };
+      }
+
+      options = options || {};
+
+      return this.number(Object.assign({}, options, {
+        precision: options.precision || 0.01
+      }))
+  }
+  
+  /**
    * takes an array and returns a random element of the array
    *
    * @method faker.random.arrayElement

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -85,6 +85,83 @@ describe("random.js", function () {
     })
   });
 
+  describe("float", function() {
+
+    it("returns a random float with a default precision value (0.01)", function() {
+      var number = faker.random.float();
+      assert.equal(number, Number(number.toFixed(2)));
+    });
+
+    it("returns a random float given a precision value", function() {
+      var number = faker.random.float(0.001);
+      assert.equal(number, Number(number.toFixed(3)));
+    });
+
+    it("returns a random number given a maximum value as Object", function() {
+      var options = { max: 10 };
+      assert.ok(faker.random.float(options) <= options.max);
+    });
+
+    it("returns a random number given a maximum value of 0", function() {
+      var options = { max: 0 };
+      assert.ok(faker.random.float(options) === 0);
+    });
+
+    it("returns a random number given a negative number minimum and maximum value of 0", function() {
+      var options = { min: -100, max: 0 };
+      assert.ok(faker.random.float(options) <= options.max);
+    });
+
+    it("returns a random number between a range", function() {
+      var options = { min: 22, max: 33 };
+      for(var i = 0; i < 5; i++) {
+        var randomNumber = faker.random.float(options);
+        assert.ok(randomNumber >= options.min);
+        assert.ok(randomNumber <= options.max);
+      }
+    });
+
+    it("provides numbers with a given precision", function() {
+      var options = { min: 0, max: 1.5, precision: 0.5 };
+      var results = _.chain(_.range(50))
+        .map(function() {
+          return faker.random.float(options);
+        })
+        .uniq()
+        .value()
+        .sort();
+
+      assert.ok(_.includes(results, 0.5));
+      assert.ok(_.includes(results, 1.0));
+
+      assert.equal(results[0], 0);
+      assert.equal(_.last(results), 1.5);
+
+    });
+
+    it("provides numbers with a with exact precision", function() {
+      var options = { min: 0.5, max: 0.99, precision: 0.01 };
+      for(var i = 0; i < 100; i++) {
+        var number = faker.random.float(options);
+        assert.equal(number, Number(number.toFixed(2)));
+      }
+    });
+
+    it("should not modify the input object", function() {
+      var min = 1;
+      var max = 2;
+      var opts = {
+        min: min,
+        max: max
+      };
+
+      faker.random.float(opts);
+
+      assert.equal(opts.min, min);
+      assert.equal(opts.max, max);
+    });
+  });
+
   describe('arrayElement', function() {
     it('returns a random element in the array', function() {
       var testArray = ['hello', 'to', 'you', 'my', 'friend'];


### PR DESCRIPTION
- Extends the `faker.random.number` float to automatically return a 0.01 precision float
- First parameter is set as the precision value

I've decided to create a PR for this feature because I was mocking float values here and there and found that setting with `faker.random.number({ precision: 0.01 })` was a bit verbose. Further to that, when I started using faker I didn't know how to create floats, took me a while to find out how I could do it. Hoping this method makes it easier and clearer from the start.

Love your work, it's been immensely helpful! Especially like some of the product names it generates, "Rustic Plastic Shirt" indeed. :)