### PR TITLE
feat(internet): Update default behavior of faker.internet.email

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -26,11 +26,23 @@ var Internet = function (faker) {
    * @method faker.internet.email
    * @param {string} firstName
    * @param {string} lastName
-   * @param {string} provider
+   * @param {string|string[]} provider
+   * @param {boolean} useFreeProviders
    */
-  self.email = function (firstName, lastName, provider) {
-      provider = provider || faker.random.arrayElement(faker.definitions.internet.free_email);
-      return  faker.helpers.slugify(faker.internet.userName(firstName, lastName)) + "@" + provider;
+  self.email = function (firstName, lastName, provider, useFreeProviders) {
+      var defaultProvider = useFreeProviders
+        ? faker.random.arrayElement(faker.definitions.internet.free_email)
+        : faker.internet.domainName()
+      if (provider) {
+        provider = typeof provider === 'string' && provider.length > 0
+          ? provider
+          : Array.isArray(provider) && provider.length > 0
+            ? faker.random.arrayElement(provider)
+            : defaultProvider
+      } else {
+        provider = defaultProvider
+      }
+      return faker.helpers.slugify(faker.internet.userName(firstName, lastName)) + "@" + provider;
   };
 
   self.email.schema = {
@@ -48,9 +60,14 @@ var Internet = function (faker) {
         "description": "The last name of the user"
       },
       "provider": {
-        "type": "string",
+        "type": "string|string[]",
         "required": false,
-        "description": "The domain of the user"
+        "description": "The domain(s) of the user. Can be a list of domains or a single domain"
+      },
+      "useFreeProviders": {
+        "type": "boolean",
+        "required": false,
+        "description": "Use free email providers [gmail.com, hotmail.com, yahoo.com] or a random provider"
       }
     }
   };

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -32,6 +32,33 @@ describe("internet.js", function () {
       });
     });
 
+    describe("trulyRandomEmailProvider", function () {
+        it("returns an email with random provider", function () {
+            var email = faker.internet.email();
+            var res = email.split("@");
+            res = res[1];
+            const freeEmailProviders = faker.definitions.internet.free_email
+            freeEmailProviders.forEach(provider => {
+                assert.notEqual(res, provider)
+            })
+        });
+      });
+      
+    describe("onlyFreeEmailProvider", function () {
+        it("returns an email with one of the free providers", function () {
+            var email1 = faker.internet.email(undefined, undefined, undefined, true);
+            var email2 = faker.internet.email(faker.name.firstName(), faker.name.lastName(), [], true);
+            var email3 = faker.internet.email(faker.name.firstName(), faker.name.lastName(), undefined, true);
+            var res1 = email1.split("@")[1];
+            var res2 = email2.split("@")[1];
+            var res3 = email3.split("@")[1];
+            const freeEmailProviders = faker.definitions.internet.free_email
+            assert.ok(freeEmailProviders.includes(res1))
+            assert.ok(freeEmailProviders.includes(res2))
+            assert.ok(freeEmailProviders.includes(res3))
+        });
+      });
+
     describe("userName()", function () {
         it("occasionally returns a single firstName", function () {
             sinon.stub(faker.random, 'number').returns(0);


### PR DESCRIPTION
## Description
feat(internet): Change default behavior of `faker.internet.email` to use random domain provider. Also extend api to allow a list of custom domain providers
This is regarding #544

## This PR contains
- Updates to the `faker.internet.email` module
  - By default a random email provider is used instead of only free providers
  - Provider now accepts a single provider or an array of custom providers
  - Default handling for all cases
- Unit tests to test above mentioned changes
- Unit tests passing and gulp operations are successful

## Notes:
I've specifically extended the current API to avoid any breaking changes
If something should be done differently, please let me know.
Comments/feedback welcome