### PR TITLE
Remove the number 2008 from pl/address/country.js

### DIFF
--- a/lib/locales/pl/address/country.js
+++ b/lib/locales/pl/address/country.js
@@ -182,7 +182,6 @@ module["exports"] = [
   "Uganda",
   "Ukraina",
   "Urugwaj",
-  2008,
   "Uzbekistan",
   "Vanuatu",
   "Watykan",


### PR DESCRIPTION
Ran schema & type-safety check over locales and found some obvious errors.

Mostly doing these checks in preparation of a new fast binary storage format for locales in [**Bogus** (C# port of faker.js)](https://github.com/bchavez/Bogus).

This removes the number `2008` found in `lib\locales\pl\address\country.js`.

:fallen_leaf: :leaves: **[Distance - Falling (ft Alys Be)](https://www.youtube.com/watch?v=WIfwIv4wNCE)**