### PR TITLE
re-order of the company.bs adjective and buzz (#496)

### DIFF
--- a/lib/company.js
+++ b/lib/company.js
@@ -62,7 +62,7 @@ var Company = function (faker) {
    * @method faker.company.bs
    */
   this.bs = function () {
-    return f('{{company.bsAdjective}} {{company.bsBuzz}} {{company.bsNoun}}');
+    return f('{{company.bsBuzz}} {{company.bsAdjective}} {{company.bsNoun}}');
   }
 
   /**

--- a/test/company.unit.js
+++ b/test/company.unit.js
@@ -79,22 +79,22 @@ describe("company.js", function () {
     });
 
     describe("bs()", function () {
-        it("returns phrase comprising of a BS adjective, buzz, and noun", function () {
+        it("returns phrase comprising of a BS buzz, adjective, and noun", function () {
             sinon.spy(faker.random, 'arrayElement');
-            sinon.spy(faker.company, 'bsAdjective');
             sinon.spy(faker.company, 'bsBuzz');
+            sinon.spy(faker.company, 'bsAdjective');
             sinon.spy(faker.company, 'bsNoun');
             var bs = faker.company.bs();
 
             assert.ok(typeof bs === 'string');
             assert.ok(faker.random.arrayElement.calledThrice);
-            assert.ok(faker.company.bsAdjective.calledOnce);
             assert.ok(faker.company.bsBuzz.calledOnce);
+            assert.ok(faker.company.bsAdjective.calledOnce);
             assert.ok(faker.company.bsNoun.calledOnce);
 
-            faker.random.arrayElement.restore();
-            faker.company.bsAdjective.restore();
+            faker.random.arrayElement.restore();        
             faker.company.bsBuzz.restore();
+            faker.company.bsAdjective.restore();
             faker.company.bsNoun.restore();
         });
     });


### PR DESCRIPTION
- re-orderes adjective and buzz in the company.bs template literal for a correct gramatics as sugessted in the issue #496,
- re-orders the statements in the unit test to reflect the same order as in the function for an easier read.