### PR TITLE
add directions to Address namespace

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -233,12 +233,12 @@ function Address (faker) {
    * @method faker.address.direction
    */
   this.direction = function () {
-    return faker.random.arrayElement(faker.definitions.address.direction)
+    return faker.random.arrayElement(faker.definitions.address.direction);
   }
 
   this.direction.schema = {
     "description": "Generates a direction.",
-    "sampleResults": ["NW", "S","SW", "E"]
+    "sampleResults": ["NW", "S", "SW", "E"]
   };
 
   /**

--- a/lib/address.js
+++ b/lib/address.js
@@ -32,7 +32,7 @@ function Address (faker) {
    * order to build the city name.
    *
    * If no format string is provided one of the following is randomly used:
-   * 
+   *
    * * `{{address.cityPrefix}} {{name.firstName}}{{address.citySuffix}}`
    * * `{{address.cityPrefix}} {{name.firstName}}`
    * * `{{name.firstName}}{{address.citySuffix}}`
@@ -131,7 +131,7 @@ function Address (faker) {
   this.streetSuffix = function () {
       return faker.random.arrayElement(faker.definitions.address.street_suffix);
   }
-  
+
   /**
    * streetPrefix
    *
@@ -226,7 +226,28 @@ function Address (faker) {
       min = min || -180
       return faker.random.number({max: max, min:min, precision:0.0001}).toFixed(4);
   }
-  
+
+  /**
+   * cardinal direction
+   *
+   * @method faker.address.cardDirection
+   */
+  this.cardDirection = function () {
+    return faker.random.arrayElement(faker.definitions.address.direction);
+  }
+
+  /**
+   * ordinal direction
+   *
+   * @method faker.address.ordDirection
+   */
+  this.ordDirection = function () {
+    return (
+      faker.random.arrayElement(faker.definitions.address.direction.slice(0, 2)) +
+      faker.random.arrayElement(faker.definitions.address.direction.slice(2, 4))
+    );
+  }
+
   return this;
 }
 

--- a/lib/address.js
+++ b/lib/address.js
@@ -228,12 +228,28 @@ function Address (faker) {
   }
 
   /**
+   *  direction
+   *
+   * @method faker.address.direction
+   */
+  this.direction = function () {
+    return faker.random.arrayElement(faker.definitions.address.direction)
+  }
+
+  this.direction.schema = {
+    "description": "Generates a direction.",
+    "sampleResults": ["NW", "S","SW", "E"]
+  };
+
+  /**
    * cardinal direction
    *
    * @method faker.address.cardinalDirection
    */
   this.cardinalDirection = function () {
-    return faker.random.arrayElement(faker.definitions.address.direction);
+    return (
+      faker.random.arrayElement(faker.definitions.address.direction.slice(0, 4))
+    );
   }
 
   this.cardinalDirection.schema = {
@@ -248,8 +264,7 @@ function Address (faker) {
    */
   this.ordinalDirection = function () {
     return (
-      faker.random.arrayElement(faker.definitions.address.direction.slice(0, 2)) +
-      faker.random.arrayElement(faker.definitions.address.direction.slice(2, 4))
+      faker.random.arrayElement(faker.definitions.address.direction.slice(4, 8))
     );
   }
 

--- a/lib/address.js
+++ b/lib/address.js
@@ -231,46 +231,62 @@ function Address (faker) {
    *  direction
    *
    * @method faker.address.direction
+   * @param {Boolean} useAbbr return direction abbreviation. defaults to false
    */
-  this.direction = function () {
-    return faker.random.arrayElement(faker.definitions.address.direction);
+  this.direction = function (useAbbr) {
+    if (typeof useAbbr === 'undefined' || useAbbr === false) {
+      return faker.random.arrayElement(faker.definitions.address.direction);
+    }
+    return faker.random.arrayElement(faker.definitions.address.direction_abbr);
   }
 
   this.direction.schema = {
-    "description": "Generates a direction.",
-    "sampleResults": ["NW", "S", "SW", "E"]
+    "description": "Generates a direction. Use optional useAbbr bool to return abbrevation",
+    "sampleResults": ["Northwest", "South", "SW", "E"]
   };
 
   /**
    * cardinal direction
    *
    * @method faker.address.cardinalDirection
+   * @param {Boolean} useAbbr return direction abbreviation. defaults to false
    */
-  this.cardinalDirection = function () {
+  this.cardinalDirection = function (useAbbr) {
+    if (typeof useAbbr === 'undefined' || useAbbr === false) {
+      return (
+        faker.random.arrayElement(faker.definitions.address.direction.slice(0, 4))
+      );
+    }
     return (
-      faker.random.arrayElement(faker.definitions.address.direction.slice(0, 4))
+      faker.random.arrayElement(faker.definitions.address.direction_abbr.slice(0, 4))
     );
   }
 
   this.cardinalDirection.schema = {
-    "description": "Generates a cardinal direction.",
-    "sampleResults": ["N", "S", "E", "W"]
+    "description": "Generates a cardinal direction. Use optional useAbbr boolean to return abbrevation",
+    "sampleResults": ["North", "South", "E", "W"]
   };
 
   /**
    * ordinal direction
    *
    * @method faker.address.ordinalDirection
+   * @param {Boolean} useAbbr return direction abbreviation. defaults to false
    */
-  this.ordinalDirection = function () {
+  this.ordinalDirection = function (useAbbr) {
+    if (typeof useAbbr === 'undefined' || useAbbr === false) {
+      return (
+        faker.random.arrayElement(faker.definitions.address.direction.slice(4, 8))
+      );
+    }
     return (
-      faker.random.arrayElement(faker.definitions.address.direction.slice(4, 8))
+      faker.random.arrayElement(faker.definitions.address.direction_abbr.slice(4, 8))
     );
   }
 
   this.ordinalDirection.schema = {
-    "description": "Generates an ordinal direction.",
-    "sampleResults": ["NW", "SE", "SW", "NE"]
+    "description": "Generates an ordinal direction. Use optional useAbbr boolean to return abbrevation",
+    "sampleResults": ["Northwest", "Southeast", "SW", "NE"]
   };
 
   return this;

--- a/lib/address.js
+++ b/lib/address.js
@@ -230,26 +230,35 @@ function Address (faker) {
   /**
    * cardinal direction
    *
-   * @method faker.address.cardDirection
+   * @method faker.address.cardinalDirection
    */
-  this.cardDirection = function () {
+  this.cardinalDirection = function () {
     return faker.random.arrayElement(faker.definitions.address.direction);
   }
+
+  this.cardinalDirection.schema = {
+    "description": "Generates a cardinal direction.",
+    "sampleResults": ["N", "S", "E", "W"]
+  };
 
   /**
    * ordinal direction
    *
-   * @method faker.address.ordDirection
+   * @method faker.address.ordinalDirection
    */
-  this.ordDirection = function () {
+  this.ordinalDirection = function () {
     return (
       faker.random.arrayElement(faker.definitions.address.direction.slice(0, 2)) +
       faker.random.arrayElement(faker.definitions.address.direction.slice(2, 4))
     );
   }
 
+  this.ordinalDirection.schema = {
+    "description": "Generates an ordinal direction.",
+    "sampleResults": ["NW", "SE", "SW", "NE"]
+  };
+
   return this;
 }
-
 
 module.exports = Address;

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ function Faker (opts) {
 
   var _definitions = {
     "name": ["first_name", "last_name", "prefix", "suffix", "gender", "title", "male_first_name", "female_first_name", "male_middle_name", "female_middle_name", "male_last_name", "female_last_name"],
-    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "postcode", "direction"],
+    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "postcode", "direction", "direction_abbr"],
     "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb", "suffix"],
     "lorem": ["words"],
     "hacker": ["abbreviation", "adjective", "noun", "verb", "ingverb", "phrase"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ function Faker (opts) {
 
   var _definitions = {
     "name": ["first_name", "last_name", "prefix", "suffix", "gender", "title", "male_first_name", "female_first_name", "male_middle_name", "female_middle_name", "male_last_name", "female_last_name"],
-    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "postcode"],
+    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "postcode", "direction"],
     "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb", "suffix"],
     "lorem": ["words"],
     "hacker": ["abbreviation", "adjective", "noun", "verb", "ingverb", "phrase"],

--- a/lib/locales/en/address/direction.js
+++ b/lib/locales/en/address/direction.js
@@ -1,6 +1,10 @@
 module["exports"] = [
   "N",
-  "S",
   "E",
-  "W"
+  "S",
+  "W",
+  "NE",
+  "NW",
+  "SE",
+  "SW"
 ];

--- a/lib/locales/en/address/direction.js
+++ b/lib/locales/en/address/direction.js
@@ -1,10 +1,10 @@
 module["exports"] = [
-  "N",
-  "E",
-  "S",
-  "W",
-  "NE",
-  "NW",
-  "SE",
-  "SW"
+  "North",
+  "East",
+  "South",
+  "West",
+  "Northeast",
+  "Northwest",
+  "Southeast",
+  "Southwest"
 ];

--- a/lib/locales/en/address/direction.js
+++ b/lib/locales/en/address/direction.js
@@ -1,0 +1,6 @@
+module["exports"] = [
+  "N",
+  "S",
+  "E",
+  "W"
+];

--- a/lib/locales/en/address/direction_abbr.js
+++ b/lib/locales/en/address/direction_abbr.js
@@ -1,0 +1,10 @@
+module["exports"] = [
+  "N",
+  "E",
+  "S",
+  "W",
+  "NE",
+  "NW",
+  "SE",
+  "SW"
+];

--- a/lib/locales/en/address/index.js
+++ b/lib/locales/en/address/index.js
@@ -17,3 +17,4 @@ address.city = require("./city");
 address.street_name = require("./street_name");
 address.street_address = require("./street_address");
 address.default_country = require("./default_country");
+address.direction = require("./direction");

--- a/lib/locales/en/address/index.js
+++ b/lib/locales/en/address/index.js
@@ -18,3 +18,4 @@ address.street_name = require("./street_name");
 address.street_address = require("./street_address");
 address.default_country = require("./default_country");
 address.direction = require("./direction");
+address.direction_abbr = require("./direction_abbr");

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -308,4 +308,23 @@ describe("address.js", function () {
         });
     });
 
+    describe("ordinalDirection()", function () {
+        it("returns random ordinal direction", function () {
+            sinon.stub(faker.address, 'ordinalDirection').returns('W');
+            var ordinalDirection = faker.address.ordinalDirection();
+
+            assert.equal(ordinalDirection, 'W');
+            faker.address.ordinalDirection.restore();
+        })
+    })
+
+    describe("cardinalDirection()", function () {
+        it("returns random cardinal direction", function () {
+            sinon.stub(faker.address, 'cardinalDirection').returns('NW');
+            var cardinalDirection = faker.address.cardinalDirection();
+
+            assert.equal(cardinalDirection, 'NW');
+            faker.address.cardinalDirection.restore();
+        })
+    })
 });

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -308,6 +308,16 @@ describe("address.js", function () {
         });
     });
 
+    describe("direction()", function () {
+        it("returns random direction", function () {
+            sinon.stub(faker.address, 'direction').returns('N');
+            var direction = faker.address.direction();
+
+            assert.equal(direction, 'N');
+            faker.address.direction.restore();
+        })
+    })
+
     describe("ordinalDirection()", function () {
         it("returns random ordinal direction", function () {
             sinon.stub(faker.address, 'ordinalDirection').returns('W');

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -310,8 +310,16 @@ describe("address.js", function () {
 
     describe("direction()", function () {
         it("returns random direction", function () {
-            sinon.stub(faker.address, 'direction').returns('N');
+            sinon.stub(faker.address, 'direction').returns('North');
             var direction = faker.address.direction();
+
+            assert.equal(direction, 'North');
+            faker.address.direction.restore();
+        })
+
+        it("returns abbreviation when useAbbr is true", function () {
+            sinon.stub(faker.address, 'direction').returns('N');
+            var direction = faker.address.direction(true);
 
             assert.equal(direction, 'N');
             faker.address.direction.restore();
@@ -320,8 +328,16 @@ describe("address.js", function () {
 
     describe("ordinalDirection()", function () {
         it("returns random ordinal direction", function () {
-            sinon.stub(faker.address, 'ordinalDirection').returns('W');
+            sinon.stub(faker.address, 'ordinalDirection').returns('West');
             var ordinalDirection = faker.address.ordinalDirection();
+
+            assert.equal(ordinalDirection, 'West');
+            faker.address.ordinalDirection.restore();
+        })
+
+        it("returns abbreviation when useAbbr is true", function () {
+            sinon.stub(faker.address, 'ordinalDirection').returns('W');
+            var ordinalDirection = faker.address.ordinalDirection(true);
 
             assert.equal(ordinalDirection, 'W');
             faker.address.ordinalDirection.restore();
@@ -330,8 +346,16 @@ describe("address.js", function () {
 
     describe("cardinalDirection()", function () {
         it("returns random cardinal direction", function () {
-            sinon.stub(faker.address, 'cardinalDirection').returns('NW');
+            sinon.stub(faker.address, 'cardinalDirection').returns('Northwest');
             var cardinalDirection = faker.address.cardinalDirection();
+
+            assert.equal(cardinalDirection, 'Northwest');
+            faker.address.cardinalDirection.restore();
+        })
+
+        it("returns abbreviation when useAbbr is true", function () {
+            sinon.stub(faker.address, 'cardinalDirection').returns('NW');
+            var cardinalDirection = faker.address.cardinalDirection(true);
 
             assert.equal(cardinalDirection, 'NW');
             faker.address.cardinalDirection.restore();


### PR DESCRIPTION
# Directions

- `faker.address.direction()` returns random direction
- `faker.address.cardinalDirection()` returns cardinal direction (N/E/S/W)
- `faker.address.ordinalDirection()` returns ordinal direction (NE/NW/SE/SW)

includes unit tests

Addresses issue #457 