### PR TITLE
Fix pt_BR city suffixes

### DIFF
--- a/lib/locales/pt_BR/address/city_suffix.js
+++ b/lib/locales/pt_BR/address/city_suffix.js
@@ -1,6 +1,7 @@
 module["exports"] = [
-  "do Descoberto",
-  "de Nossa Senhora",
-  "do Norte",
-  "do Sul"
+  " do Descoberto",
+  " de Nossa Senhora",
+  " do Norte",
+  " do Sul",
+  "lândia"
 ];


### PR DESCRIPTION
These are concatenated to cityPrefix without a space separator,
the example suffixes (which are full words) need to begin with a
space. I also added a `lândia` suffix which shouldn't begin with
a space.