### PR TITLE
don't npmignore build/build/faker.js 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 .npm/
-build/
+build/*
+build/build/*
+!build/build/faker.js
+!build/build/faker.min.js
 doc/
 examples/
 meteor/


### PR DESCRIPTION
don't npmignore build/build/faker.js or build/build/faker.min.js
even though we ignore the rest of build/*

I tested it locally using `npm pack`

Fixes https://github.com/Marak/faker.js/issues/575