### PR TITLE
Fix bitcoinAddress generator

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -161,12 +161,12 @@ var Finance = function (faker) {
    * @method  faker.finance.bitcoinAddress
    */
   self.bitcoinAddress = function () {
-    var addressLength = faker.random.number({ min: 27, max: 34 });
+    var addressLength = faker.random.number({ min: 25, max: 34 });
 
     var address = faker.random.arrayElement(['1', '3']);
 
     for (var i = 0; i < addressLength - 1; i++)
-      address += faker.random.alphaNumeric().toUpperCase();
+      address += faker.random.arrayElement('123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'.split(''));
 
     return address;
   }

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -234,7 +234,7 @@ describe('finance.js', function () {
         it("returns a random bitcoin address", function(){
             var bitcoinAddress = faker.finance.bitcoinAddress();
 
-            assert.ok(bitcoinAddress.match(/^[A-Z0-9.]{27,34}$/));
+            assert.ok(bitcoinAddress.match(/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/));
         });
     });
 
@@ -308,7 +308,7 @@ describe('finance.js', function () {
         assert.ok(luhnFormula(number));
       });
     });
-    
+
     describe("creditCardCVV()", function(){
       it("returns a random credit card CVV", function(){
         var cvv = faker.finance.creditCardCVV();
@@ -316,7 +316,7 @@ describe('finance.js', function () {
         assert.ok(cvv.match(/^[0-9]{3}$/));
       });
     });
-      
+
 
     describe("iban()", function () {
         var ibanLib = require('../lib/iban');


### PR DESCRIPTION
The current `bitcoinAddress` generator version is returning invalid bitcoin addresses. The addresses consist of random digits and uppercase and lowercase letters, **with the exception** that the uppercase letter "O", uppercase letter "I", lowercase letter "l", and the number "0" are never used to prevent visual ambiguity. (https://en.bitcoin.it/wiki/Address)

This PR purposes a fix for this issue.
  
**Note**:
Travis failed to build my PR but I suspect it has nothing to do with the changes that I made:
```sh
npm ERR! Linux 4.9.6-040906-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v6.12.0/bin/node" "/home/travis/.nvm/versions/node/v6.12.0/bin/npm" "install"
npm ERR! node v6.12.0
npm ERR! npm  v3.10.10
npm ERR! code ETIMEDOUT
npm ERR! errno ETIMEDOUT
npm ERR! syscall connect

npm ERR! network connect ETIMEDOUT 151.101.32.162:443
npm ERR! network This is most likely not a problem with npm itself
npm ERR! network and is related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network 
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'

npm ERR! Please include the following file with any support request:
npm ERR!     /home/travis/build/Marak/faker.js/npm-debug.log

The command "eval npm install  " failed. Retrying, 2 of 3.
```