### PR TITLE
Reset startTime appropriately

### DIFF
--- a/vendor/unique.js
+++ b/vendor/unique.js
@@ -18,7 +18,7 @@ var maxTime = 5000;
 var maxRetries = 50;
 
 // time the script started
-var startTime = new Date().getTime();
+var startTime = null;
 
 // current iteration or retries of unique.exec ( current loop depth )
 var currentIterations = 0;
@@ -41,6 +41,9 @@ unique.errorMessage = function (now, code) {
 
 unique.exec = function (method, args, opts) {
 
+  if (currentIterations === 0) {
+    startTime = new Date().getTime();
+  }
   var now = new Date().getTime();
 
   opts = opts || {};


### PR DESCRIPTION
Note #466 and [my comment on times](https://github.com/Marak/faker.js/issues/466#issuecomment-357140244). Refreshes `startTime` at 0 loop depth, preventing scripts which last longer than 5 seconds from throwing.

BTW I needed to use a fork of `gulp-gh-pages` because [this PR](https://github.com/shinnn/gulp-gh-pages/pull/117) isn't merged, which fixes [this issue](https://github.com/shinnn/gulp-gh-pages/issues/116), which is currently breaking your gulp build :smile: 