### PR TITLE
Bugfix random.shuffle last element.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -191,17 +191,24 @@ var Helpers = function (faker) {
    };
 
   /**
-   * takes an array and returns it randomized
+   * takes an array and randomizes it in place then returns it
+   * 
+   * uses the modern version of the Fisher–Yates algorithm
    *
    * @method faker.helpers.shuffle
    * @param {array} o
    */
   self.shuffle = function (o) {
       if (typeof o === 'undefined' || o.length === 0) {
-        return [];
+        return o || [];
       }
       o = o || ["a", "b", "c"];
-      for (var j, x, i = o.length-1; i; j = faker.random.number(i), x = o[--i], o[i] = o[j], o[j] = x);
+      for (var x, j, i = o.length - 1; i > 0; --i) {
+        j = faker.random.number(i);
+        x = o[i];
+        o[i] = o[j];
+        o[j] = x;
+      }
       return o;
   };
 

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -43,6 +43,19 @@ describe("helpers.js", function () {
             var shuffled = faker.helpers.shuffle([]);
             assert.ok(shuffled.length === 0);
         });
+
+        it("mutates the input array in place", function () {
+            var input = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+            var shuffled = faker.helpers.shuffle(input);
+            assert.deepEqual(shuffled, input);
+        });
+
+        it("all items shuffled as expected when seeded", function () {
+            var input = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+            faker.seed(100);
+            var shuffled = faker.helpers.shuffle(input);
+            assert.deepEqual(shuffled, ["b", "e", "a", "d", "j", "i", "h", "c", "g", "f"]);
+        });
     });
 
     describe("slugify()", function () {


### PR DESCRIPTION
There was a bug in the implementation of the modern Fisher–Yates
algorithm in that `i` was being decremented prematurely in each loop.
This caused the last element of the array to never be swapped
and therefore remain the last element.

Updated doc to denote the provided array is shuffled in place.