### PR TITLE
Handle negative maximum with no minimum (random.number)

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -30,13 +30,13 @@ function Random (faker, seed) {
 
     options = options || {};
 
-    if (typeof options.min === "undefined") {
-      options.min = 0;
-    }
-
     if (typeof options.max === "undefined") {
       options.max = 99999;
     }
+    if (typeof options.min === "undefined") {
+      options.min = options.max < 0 ? -99999 : 0;
+    }
+
     if (typeof options.precision === "undefined") {
       options.precision = 1;
     }

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -24,6 +24,11 @@ describe("random.js", function () {
       assert.ok(faker.random.number(options) === 0);
     });
 
+    it("returns a random number given no minimum and a negative number maximum", function() {
+      var options = { max: -10 };
+      assert.ok(faker.random.number(options) <= options.max);
+    });
+
     it("returns a random number given a negative number minimum and maximum value of 0", function() {
       var options = { min: -100, max: 0 };
       assert.ok(faker.random.number(options) <= options.max);


### PR DESCRIPTION
Fixes #647.  Given a negative maximum and no minimum value,
return a value that is consistently <= max.