### PR TITLE
Fix gulp build process on Windows

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -17,13 +17,16 @@ var gulp = require('gulp');
 var jsdoc = require('gulp-jsdoc3');
 var uglify = require('gulp-uglify');
 var rename = require('gulp-rename');
-var ghPages = require('gulp-gh-pages');
+var ghPages = require('gh-pages');
 var mustache = require('gulp-mustache');
 var browserify = require('browserify');
 var transform = require('vinyl-transform');
 var path = require('path');
 var fs = require('fs');
-var through = require('through2')
+var gracefulFs = require('graceful-fs');
+var through = require('through2');
+
+gracefulFs.gracefulify(fs);
 
 gulp.task('browser-package', function() {
 
@@ -60,8 +63,7 @@ gulp.task('browser-package', function() {
 
 // pushes jsdoc changes to gh-pages branch
 gulp.task('gh-pages', function(cb) {
-  return gulp.src('../doc/**/*')
-     .pipe(ghPages());
+  ghPages.publish(path.join(__dirname, '..', 'doc'), cb);
 });
 
 gulp.task('jsdoc', function (cb) {
@@ -113,7 +115,7 @@ gulp.task('documentation', function(cb) {
        'currentYear': new Date().getFullYear()
      }))
     .pipe(rename("./Readme.md"))
-    .pipe(gulp.dest('../'))
+    .pipe(gulp.dest('../'));
 
 });
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "node_modules/.bin/jshint ./lib --config ./.jshintrc",
     "test": "node_modules/.bin/mocha test/*.*.js",
-    "build": "cd build && ../node_modules/.bin/gulp && cd ../",
+    "build": "cd build && \"../node_modules/.bin/gulp\" && cd ../",
     "doc": "jsdoc -c conf.json -t ./node_modules/ink-docstrap/template -R README.md lib",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
@@ -44,8 +44,9 @@
   "devDependencies": {
     "browserify": "5.11.1",
     "coveralls": "^2.13.1",
+    "gh-pages": "^1.2.0",
+    "graceful-fs": "^4.1.11",
     "gulp": "^3.9.1",
-    "gulp-gh-pages": "^0.5.4",
     "gulp-jsdoc3": "^0.2.1",
     "gulp-mustache": "0.4.0",
     "gulp-rename": "1.2.0",


### PR DESCRIPTION
There are a lot of issues preventing gulp from running on Windows. This PR fixes **most, but not all** of these issues.

- The gulp command (../node_modules/.bin/gulp) is wrapped in double quotes to allow it to run on Windows. (The command was previously interpreted as "..." which obviously broke things.) Unfortunately, fixing this only revealed another problem with the Windows build.
- Added graceful-fs to gracefulify fs. This allows us to get around the open file limit on Windows.
- Replace gulp-gh-pages with gh-pages. (gulp-gh-pages depends on a package which crashes on Windows, and gh-pages supposedly has more active development anyway.)
- Added missing semicolons. (They did not break the build, but they broke my heart.)

There is still one more issue with running the build script on Windows. I don't know exactly why, but node versions greater than ~4.4.4 fail the build process with the error "TypeError: Path must be a string. Received undefined". The workaround is to use nvm-windows to install node 4.4.4 and run gulp using this node version.

I don't have linux to ensure the changes are backwards compatible and will remain viable on the original development platform, so if possible I'd like someone else to pull my changes and verify the build process behaves as expected.

This PR addresses part of #622 