### PR TITLE
feat: add "blockchains" as a company.bs_noun

### DIFF
--- a/lib/locales/en/company/bs_noun.js
+++ b/lib/locales/en/company/bs_noun.js
@@ -42,5 +42,6 @@ module["exports"] = [
   "functionalities",
   "experiences",
   "web services",
-  "methodologies"
+  "methodologies",
+  "blockchains"
 ];


### PR DESCRIPTION
Attempts to keep `faker.company.bsNoun()` hip and trendy by adding `blockchains` to the list of available nouns.

Example new `faker.company.bs()` output:

```
leading-edge facilitate blockchains
front-end cultivate blockchains
scalable maximize blockchains
extensible enhance blockchains
end-to-end deliver blockchains
visionary revolutionize blockchains
turn-key innovate blockchains
world-class enhance blockchains
intuitive optimize blockchains
viral transition blockchains
```
