### PR TITLE
Ensure faker.random.word does not return more than one word

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -180,8 +180,8 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
-
+    var result = faker.fake('{{' + randomWordMethod + '}}');
+    return faker.random.arrayElement(result.split(' '));
   }
 
   /**


### PR DESCRIPTION
faker.random.word() has a bug where sometimes it returns a string with more than one word. This PR fixes that bug by splitting the previous result on spaces and selecting randomly from the words returned.

Fixes #661 
Fixes #602 
