### PR TITLE
Allowed gender passed to name.firstName(gender) to be a string

### DIFF
--- a/lib/name.js
+++ b/lib/name.js
@@ -15,6 +15,16 @@ function Name (faker) {
     if (typeof faker.definitions.name.male_first_name !== "undefined" && typeof faker.definitions.name.female_first_name !== "undefined") {
       // some locale datasets ( like ru ) have first_name split by gender. since the name.first_name field does not exist in these datasets,
       // we must randomly pick a name from either gender array so faker.name.firstName will return the correct locale data ( and not fallback )
+
+      if(typeof gender === 'string') {
+        if(gender.toLowerCase() === 'male') {
+          gender = 0;
+        }
+        else if(gender.toLowerCase() === 'female') {
+          gender = 1;
+        }
+      }
+
       if (typeof gender !== 'number') {
         if(typeof faker.definitions.name.first_name === "undefined") {
           gender = faker.random.number(1);

--- a/test/name.unit.js
+++ b/test/name.unit.js
@@ -5,6 +5,11 @@ if (typeof module !== 'undefined') {
 
 }
 
+function assertInArray(value, array) {
+    var idx = array.indexOf(value);
+    assert.notEqual(idx, -1);
+}
+
 describe("name.js", function () {
     describe("firstName()", function () {
         it("returns a random name", function () {
@@ -14,6 +19,24 @@ describe("name.js", function () {
             assert.equal(first_name, 'foo');
 
             faker.name.firstName.restore();
+        });
+        
+        it("returns a gender-specific name when passed a number", function () {
+            for (var q = 0; q < 30; q++) {
+                var gender = Math.floor(Math.random() * 2);
+                var name = faker.name.firstName(gender);
+                if (gender === 0) assertInArray(name, faker.definitions.name.male_first_name);
+                else assertInArray(name, faker.definitions.name.female_first_name);
+            }
+        });
+        
+        it("returns a gender-specific name when passed a string", function () {
+            for (var q = 0; q < 30; q++) {
+                var gender = Math.floor(Math.random() * 2);
+                var genderString = (gender === 0 ? 'male' : 'female');
+                var name = faker.name.firstName(genderString);
+                assertInArray(name, faker.definitions.name[genderString + '_first_name']);
+            }
         });
     });
 


### PR DESCRIPTION
Added a feature where you can pass a string into `faker.name.firstName(gender)` 

- Accepts "male" or "female" in English (all other strings fall back to non-gendered names)
- Case insensitive 
- Unit tests created for new inputs

Fixes #677 