### PR TITLE
fix: ammend tests for bitcoin addresses

### DIFF
--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -234,7 +234,12 @@ describe('finance.js', function () {
         it("returns a random bitcoin address", function(){
             var bitcoinAddress = faker.finance.bitcoinAddress();
 
-            assert.ok(bitcoinAddress.match(/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/));
+            /**
+             *  Note: Although the total length of a Bitcoin address can be 25-33 characters, regex quantifiers only check the proceding token
+             *  Therefore we take one from the total length of the address not including the first character ([13])
+             */
+
+            assert.ok(bitcoinAddress.match(/^[13][a-km-zA-HJ-NP-Z1-9]{24,33}$/));
         });
     });
 


### PR DESCRIPTION
The tests for bitcoin addresses had an invalid regex.

@Marak I've left a note here explaining why we use 24,33 and not 25,34 as I can see why this would be confusing to anyone not too familiar with Regex... but if you think this is unnecessary I can remove it.

The regex quantifier only checks the preceding token so we do not need to check the length including the first character which is already tested via [13]