### PR TITLE
feat(testing): log seed to test console

### DIFF
--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -2,10 +2,14 @@ if (typeof module !== 'undefined') {
     var assert = require('assert');
     var sinon = require('sinon');
     var faker = require('../index');
+    var seeder = require('./support/seeder');
 }
 
-
 describe('finance.js', function () {
+    before(() => {
+        seeder();
+    });
+
     describe('account( length )', function () {
 
         it('should supply a default length if no length is passed', function () {

--- a/test/support/seeder.js
+++ b/test/support/seeder.js
@@ -1,0 +1,17 @@
+if (typeof module !== 'undefined') {
+    var faker = require('../../index');
+}
+
+/**
+ * Tells faker to use a generated seed. Logs to the console.
+ * You can also set your SEED environment variable to override this.
+ */
+module.exports = function Seeder () {
+    var seed = process.env.SEED ? parseInt(process.env.SEED) : Math.floor(Math.random() * 1000000);
+
+    faker.seed(seed);
+    
+    console.log("Seed:", seed);
+
+    return seed;
+}


### PR DESCRIPTION
This is a proposal to add seeding to the current unit tests.

When we encounter unit test failures that only fail under specific values, it can be a bit taxing to keep having to re-run the test suite in hopes that the failure happens again.

If we log the seed to the test report, we can use this to make the test fail every time.

Thoughts?

Many thanks