### PR TITLE
build script support for localeFallback

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -157,11 +157,12 @@ gulp.task('nodeLocalRequires', function (cb){
   for (var locale in locales) {
     var localeFile = path.normalize(__dirname + "/../locale/" + locale + ".js");
     var localeRequire = '';
+    var localeFallback = locales[locale].localeFallback || "en";
     localeRequire += "var Faker = require('../lib');\n";
-    localeRequire += "var faker = new Faker({ locale: '" + locale + "', localeFallback: 'en' });\n";
+    localeRequire += "var faker = new Faker({ locale: '" + locale + "', localeFallback: '" + localeFallback + "' });\n";
     // TODO: better fallback support
     localeRequire += "faker.locales['" + locale + "'] = require('../lib/locales/" + locale + "');\n";
-    localeRequire += "faker.locales['" + 'en' + "'] = require('../lib/locales/" + 'en' + "');\n";
+    localeRequire += "faker.locales['" + localeFallback + "'] = require('../lib/locales/" + localeFallback + "');\n";
     localeRequire += "module['exports'] = faker;\n";
     fs.writeFileSync(localeFile, localeRequire);
   }

--- a/lib/locales/nl_BE/index.js
+++ b/lib/locales/nl_BE/index.js
@@ -6,3 +6,4 @@ nl_BE.company = require("./company");
 nl_BE.internet = require("./internet");
 nl_BE.name = require("./name");
 nl_BE.phone_number = require("./phone_number");
+nl_BE.localeFallback = "nl";


### PR DESCRIPTION
`lib/locales/*/index.js` export `localeFallback` to override the fallback.  Only `nl_BE` currently uses this feature, and that locale was changed appropriately.