### PR TITLE
fix(date): Allow for `refDate` in `soon()`, `recent()`

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -12,7 +12,11 @@ var _Date = function (faker) {
    * @param {date} refDate
    */
   self.past = function (years, refDate) {
-      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
+      var date = new Date();
+      if (refDate !== undefined) {
+          date = new Date(Date.parse(refDate));
+      }
+
       var range = {
         min: 1000,
         max: (years || 1) * 365 * 24 * 3600 * 1000
@@ -33,7 +37,11 @@ var _Date = function (faker) {
    * @param {date} refDate
    */
   self.future = function (years, refDate) {
-      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
+      var date = new Date();
+      if (refDate !== undefined) {
+          date = new Date(Date.parse(refDate));
+      }
+
       var range = {
         min: 1000,
         max: (years || 1) * 365 * 24 * 3600 * 1000
@@ -70,7 +78,11 @@ var _Date = function (faker) {
    * @param {date} refDate
    */
   self.recent = function (days, refDate) {
-      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
+      var date = new Date();
+      if (refDate !== undefined) {
+          date = new Date(Date.parse(refDate));
+      }
+
       var range = {
         min: 1000,
         max: (days || 1) * 24 * 3600 * 1000
@@ -91,7 +103,11 @@ var _Date = function (faker) {
    * @param {date} refDate
    */
   self.soon = function (days, refDate) {
-      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
+      var date = new Date();
+      if (refDate !== undefined) {
+          date = new Date(Date.parse(refDate));
+      }
+
       var range = {
         min: 1000,
         max: (days || 1) * 24 * 3600 * 1000

--- a/lib/date.js
+++ b/lib/date.js
@@ -67,9 +67,10 @@ var _Date = function (faker) {
    *
    * @method faker.date.recent
    * @param {number} days
+   * @param {date} refDate
    */
-  self.recent = function (days) {
-      var date = new Date();
+  self.recent = function (days, refDate) {
+      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
       var range = {
         min: 1000,
         max: (days || 1) * 24 * 3600 * 1000
@@ -87,9 +88,10 @@ var _Date = function (faker) {
    *
    * @method faker.date.soon
    * @param {number} days
+   * @param {date} refDate
    */
-  self.soon = function (days) {
-      var date = new Date();
+  self.soon = function (days, refDate) {
+      var date = (refDate) ? new Date(Date.parse(refDate)) : new Date();
       var range = {
         min: 1000,
         max: (days || 1) * 24 * 3600 * 1000
@@ -145,9 +147,9 @@ var _Date = function (faker) {
 
       return faker.random.arrayElement(source);
   };
-  
+
   return self;
-  
+
 };
 
 module['exports'] = _Date;

--- a/test/date.unit.js
+++ b/test/date.unit.js
@@ -65,6 +65,19 @@ describe("date.js", function () {
             assert.ok(date <= new Date());
         });
 
+        it("returns a date N days from the recent past, starting from refDate", function () {
+
+            var days = 30;
+            var refDate = new Date(2120, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
+
+            var date = faker.date.recent(days, refDate);
+
+            var lowerBound = new Date(refDate.getTime() - (days * 24 * 60 * 60 * 1000));
+
+            assert.ok(lowerBound <= date, "`recent()` date should not be further back than `n` days ago");
+            assert.ok(date <= refDate, "`recent()` date should not be ahead of the starting date reference");
+        });
+
     });
 
     describe("soon()", function () {
@@ -73,6 +86,19 @@ describe("date.js", function () {
             var date = faker.date.soon(30);
 
             assert.ok(date >= new Date());
+        });
+
+        it("returns a date N days from the recent future, starting from refDate", function () {
+
+            var days = 30;
+            var refDate = new Date(1880, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
+
+            var date = faker.date.soon(days, refDate);
+
+            var upperBound = new Date(refDate.getTime() + (days * 24 * 60 * 60 * 1000));
+
+            assert.ok(date <= upperBound, "`soon()` date should not be further ahead than `n` days ago");
+            assert.ok(refDate <= date, "`soon()` date should not be behind the starting date reference");
         });
 
     });


### PR DESCRIPTION
Closes #686

There might be more date functions that need updating, if so just let me know what I missed.