### PR TITLE
Fix random module context when using a seed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,15 @@
 
 */
 
+function bindAll(obj) {
+    Object.keys(obj).forEach(function(meth) {
+        if (typeof obj[meth] === 'function') {
+            obj[meth] = obj[meth].bind(obj);
+        }
+    });
+    return obj;
+}
+
 /**
  *
  * @namespace faker
@@ -37,15 +46,6 @@ function Faker (opts) {
   self.localeFallback = localeFallback;
 
   self.definitions = {};
-
-  function bindAll(obj) {
-      Object.keys(obj).forEach(function(meth) {
-          if (typeof obj[meth] === 'function') {
-              obj[meth] = obj[meth].bind(obj);
-          }
-      });
-      return obj;
-  }
 
   var Fake = require('./fake');
   self.fake = new Fake(self).fake;
@@ -156,6 +156,6 @@ Faker.prototype.setLocale = function (locale) {
 Faker.prototype.seed = function(value) {
   var Random = require('./random');
   this.seedValue = value;
-  this.random = new Random(this, this.seedValue);
+  this.random = bindAll(new Random(this, this.seedValue));
 }
 module['exports'] = Faker;


### PR DESCRIPTION
Bind the methods for the random module to the correct context when using a seed.

For example this fixes

```javascript
const faker = require('faker');
faker.seed(1);
faker.fake('{{random.uuid}}'); //TypeError: self.number is not a function
```