### PR TITLE
Adding support for Time Method() in Faker.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,9 @@ function Faker (opts) {
   var _Date = require('./date');
   self.date = new _Date(self);
 
+  var _Time = require('./time');
+  self.time = new _Time(self);
+
   var Commerce = require('./commerce');
   self.commerce = new Commerce(self);
 

--- a/lib/time.js
+++ b/lib/time.js
@@ -11,7 +11,11 @@ var _Time = function(faker) {
    * @method faker.time.recent
    * @param {string} outputType - 'abbr' || 'wide' || 'unix' (default choice)
    */
-  self.recent = function(outputType = "unix") {
+  self.recent = function(outputType) {
+    if (typeof outputType === "undefined") {
+        outputType = 'unix';
+    }
+
     var date = new Date();
     switch (outputType) {
       case "abbr":
@@ -21,7 +25,6 @@ var _Time = function(faker) {
         date = date.toTimeString();
         break;
       case "unix":
-      default:
         date = date.getTime();
         break;
     }

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,0 +1,23 @@
+/**
+ *
+ * @namespace faker.time
+ */
+var _Time = function (faker) {
+  var self = this;
+
+  /**
+   * between
+   *
+   * @method faker.time.recent
+   * @param {number} days
+   * @param {date} refDate
+   */
+  self.recent = function () {
+
+  };
+
+  return self;
+
+};
+
+module['exports'] = _Time;

--- a/lib/time.js
+++ b/lib/time.js
@@ -2,22 +2,33 @@
  *
  * @namespace faker.time
  */
-var _Time = function (faker) {
+var _Time = function(faker) {
   var self = this;
 
   /**
-   * between
+   * recent
    *
    * @method faker.time.recent
-   * @param {number} days
-   * @param {date} refDate
+   * @param {string} outputType - 'abbr' || 'wide' || 'unix' (default choice)
    */
-  self.recent = function () {
-
+  self.recent = function(outputType = "unix") {
+    var date = new Date();
+    switch (outputType) {
+      case "abbr":
+        date = date.toLocaleTimeString();
+        break;
+      case "wide":
+        date = date.toTimeString();
+        break;
+      case "unix":
+      default:
+        date = date.getTime();
+        break;
+    }
+    return date;
   };
 
   return self;
-
 };
 
-module['exports'] = _Time;
+module["exports"] = _Time;

--- a/test/time.unit.js
+++ b/test/time.unit.js
@@ -1,0 +1,16 @@
+if (typeof module !== 'undefined') {
+    var assert = require('assert');
+    var sinon = require('sinon');
+    var faker = require('../index');
+}
+
+describe("time.js", function () {
+    describe("recent()", function () {
+        it("returns the recent timestamp in Unix time format", function () {
+            var date = faker.time.recent();
+            assert.ok(date == new Date().getTime());
+        });
+
+    });
+
+});

--- a/test/time.unit.js
+++ b/test/time.unit.js
@@ -8,9 +8,19 @@ describe("time.js", function () {
     describe("recent()", function () {
         it("returns the recent timestamp in Unix time format", function () {
             var date = faker.time.recent();
+            assert.ok(typeof date === 'number');
             assert.ok(date == new Date().getTime());
         });
 
+        it("returns the recent timestamp in full time string format", function () {
+            var date = faker.time.recent('wide');
+            assert.ok(date == new Date().toTimeString());
+        });
+
+        it("returns the recent timestamp in abbreviated string format", function () {
+            var date = faker.time.recent('abbr');
+            assert.ok(date == new Date().toLocaleTimeString());
+        });
     });
 
 });


### PR DESCRIPTION
@Marak With respect to Github issue #699 , raising this PR to add time method support for faker.

Right now this PR adds support for recent time.

```javascript
faker.time.recent(); 
// > 1562053376052

faker.time.recent('wide');
// > "13:13:28 GMT+0530 (India Standard Time)"

faker.time.recent('abbr');
// > "13:13:47"
```

Future scopes: `past/future time in range`, `random past/future time`