### PR TITLE
Fixed faker.random.word() returning multiple words

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -78,7 +78,7 @@ function Random (faker, seed) {
       }
       return faker.random.number(opts);
   }
-  
+
   /**
    * takes an array and returns a random element of the array
    *
@@ -202,7 +202,9 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    var result = faker.fake('{{' + randomWordMethod + '}}');
+
+    return faker.random.arrayElement(result.split(' '));
 
   }
 

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -6,8 +6,17 @@ if (typeof module !== 'undefined') {
     var mersenne = require('../vendor/mersenne');
 }
 
+var sandbox;
 
 describe("random.js", function () {
+  beforeEach(function(){
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe("number", function() {
 
     it("returns a random number given a maximum value as Number", function() {
@@ -321,4 +330,14 @@ describe("random.js", function () {
     });
   })
 
+  describe("word", function () {
+    it("should return single word", function () {
+      var words = ['test', 'word'];
+      sandbox.stub(faker, 'fake').returns(words.join(' '));
+
+      var random = faker.random.word();
+
+      assert.ok(words.indexOf(random) > -1);
+    });
+  });
 });


### PR DESCRIPTION
I know lots of people waiting for this.

**Problem**
`faker.random.word()` returns multiple words instead of returning a single word.

**Fix**
This PR fixes the problem by splitting the result from faker method and returns one of the array elements.

**Issues**
Fixes #661
Fixes #602 