### PR TITLE
fix: lowercase eth addresses

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -223,7 +223,7 @@ var Finance = function (faker) {
    * @method  faker.finance.ethereumAddress
    */
   self.ethereumAddress = function () {
-    var address = faker.random.hexaDecimal(40);
+    var address = faker.random.hexaDecimal(40).toLowerCase();
 
     return address;
   };

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -246,7 +246,7 @@ describe('finance.js', function () {
     describe("ethereumAddress()", function(){
         it("returns a random ethereum address", function(){
             var ethereumAddress = faker.finance.ethereumAddress();
-            assert.ok(ethereumAddress.match(/^(0x)[0-9a-f]{40}$/i));
+            assert.ok(ethereumAddress.match(/^(0x)[0-9a-f]{40}$/));
         });
     });
 


### PR DESCRIPTION
Ethereum addresses should be all lowercase.  Uppercase chars in ethereum addresses are a sort of optional checksum.  If a program is validating ethereum addresses, random capital letters in the hex string will cause the checksum to fail.