### PR TITLE
Migrate away from RawGit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@
 
 ## Demo
 
-[https://rawgit.com/Marak/faker.js/master/examples/browser/index.html](https://rawgit.com/Marak/faker.js/master/examples/browser/index.html)
+https://raw.githack.com/Marak/faker.js/master/examples/browser/index.html
 
 ## Hosted API Microservice
 


### PR DESCRIPTION
Migrate demo URL from `rawgit.com` to `raw.githack.com`.