### PR TITLE
Fix #663

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -132,7 +132,7 @@ function Address (faker) {
    * @param {Boolean} useFullAddress
    */
   this.streetAddress = function (useFullAddress) {
-      var address = Helpers.mustache(faker.definitions.address.street_address[0], {
+      var address = Helpers.templateString(faker.definitions.address.street_address[0], {
         street_name: faker.address.streetName(),
         building_number: faker.address.buildingNumber()
       })

--- a/lib/address.js
+++ b/lib/address.js
@@ -98,20 +98,27 @@ function Address (faker) {
    * @method faker.address.streetName
    */
   this.streetName = function () {
-      var result;
-      var suffix = faker.address.streetSuffix();
-      if (suffix !== "") {
-          suffix = " " + suffix
-      }
 
-      switch (faker.random.number(1)) {
-      case 0:
-          result = faker.name.lastName() + suffix;
-          break;
-      case 1:
-          result = faker.name.firstName() + suffix;
-          break;
-      }
+      var result;  
+    
+      if(!faker.definitions.address.street_root) {
+        var suffix = faker.address.streetSuffix();
+        if (suffix !== "") {
+            suffix = " " + suffix
+        }
+
+        switch (faker.random.number(1)) {
+        case 0:
+            result = faker.name.lastName() + suffix;
+            break;
+        case 1:
+            result = faker.name.firstName() + suffix;
+            break;
+        }
+      } else {
+        result = faker.random.arrayElement(faker.definitions.address.street_root)
+      }     
+      
       return result;
   }
 
@@ -125,20 +132,21 @@ function Address (faker) {
    * @param {Boolean} useFullAddress
    */
   this.streetAddress = function (useFullAddress) {
-      if (useFullAddress === undefined) { useFullAddress = false; }
-      var address = "";
-      switch (faker.random.number(2)) {
-      case 0:
-          address = Helpers.replaceSymbolWithNumber("#####") + " " + faker.address.streetName();
-          break;
-      case 1:
-          address = Helpers.replaceSymbolWithNumber("####") +  " " + faker.address.streetName();
-          break;
-      case 2:
-          address = Helpers.replaceSymbolWithNumber("###") + " " + faker.address.streetName();
-          break;
-      }
+      var address = Helpers.mustache(faker.definitions.address.street_address[0], {
+        street_name: faker.address.streetName(),
+        building_number: faker.address.buildingNumber()
+      })
+
       return useFullAddress ? (address + " " + faker.address.secondaryAddress()) : address;
+  }
+
+  /**
+   * Returns a random building number
+   * 
+   * @method faker.address.buildingNumber
+   */
+  this.buildingNumber = function() {
+    return Helpers.replaceSymbolWithNumber(faker.random.arrayElement(faker.definitions.address.building_number))
   }
 
   /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -218,6 +218,24 @@ var Helpers = function (faker) {
       return '';
     }
     for(var p in data) {
+      var re = new RegExp('{{' + p + '}}', 'g')
+      str = str.replace(re, data[p]);
+    }
+    return str;
+  };
+
+  /**
+   * templateString
+   * 
+   * @method faker.helpers.templateString
+   * @param {string} str
+   * @param {object} data
+   */
+  self.templateString = function (str, data) {
+    if (typeof str !== 'string') {
+      return '';
+    }
+    for(var p in data) {
       var re = new RegExp('#{' + p + '}', 'g')
       str = str.replace(re, data[p]);
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -214,11 +214,11 @@ var Helpers = function (faker) {
    * @param {object} data
    */
   self.mustache = function (str, data) {
-    if (typeof str === 'undefined') {
+    if (typeof str !== 'string') {
       return '';
     }
     for(var p in data) {
-      var re = new RegExp('{{' + p + '}}', 'g')
+      var re = new RegExp('#{' + p + '}', 'g')
       str = str.replace(re, data[p]);
     }
     return str;

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ function Faker (opts) {
 
   var _definitions = {
     "name": ["first_name", "last_name", "prefix", "suffix", "gender", "title", "male_prefix", "female_prefix", "male_first_name", "female_first_name", "male_middle_name", "female_middle_name", "male_last_name", "female_last_name"],
-    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "postcode", "postcode_by_state", "direction", "direction_abbr"],
+    "address": ["city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "state", "state_abbr", "street_prefix", "street_address", "street_root", "building_number", "postcode", "postcode_by_state", "direction", "direction_abbr"],
     "company": ["adjective", "noun", "descriptor", "bs_adjective", "bs_noun", "bs_verb", "suffix"],
     "lorem": ["words"],
     "hacker": ["abbreviation", "adjective", "noun", "verb", "ingverb", "phrase"],
@@ -140,7 +140,7 @@ function Faker (opts) {
       });
     });
   });
-
+  
 };
 
 Faker.prototype.setLocale = function (locale) {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const faker = require(".");
+faker.locale = "de";
+
+console.log(faker.definitions.address.building_number)
+
+function telefonNummer() {
+  return "0".concat(
+    faker.phone
+      .phoneNumber()
+      .slice(4)
+      .split("-")
+      .join(" ")
+  );
+}
+
+const firstname = faker.name.firstName();
+const lastname = faker.name.lastName();
+const adress = faker.address.streetAddress().split(" ");
+const street = adress[0];
+const buildingNumber = adress[1];
+const zipCode = faker.address.zipCode();
+const telefon = Math.random() > 0.1 ? telefonNummer() : "\\N";
+const fax = Math.random() > 0.95 ? telefonNummer() : "\\N";
+const email = faker.internet.email();
+
+console.log(faker.address.streetAddress());
+
+console.log(
+  `,${firstname},${lastname},${street},${buildingNumber},${zipCode},${telefon},${fax},${email}`
+);


### PR DESCRIPTION
This fixes #663. 
It also adds faker.address.buildingNumber. I personally already used it and since its used internally already I felt it wouldn't be an issue.
I also had to add a new helper faker.helpers.templateString. It deals with the #{} template strings used in the street_root.js files. I didn't find any other function that do this. I am however not familiar enough with the codebase to be sure.