### PR TITLE
Update options.max for random.number to Number.MAX_SAFE_INTEGER

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -35,7 +35,7 @@ function Random (faker, seed) {
     }
 
     if (typeof options.max === "undefined") {
-      options.max = 99999;
+      options.max = Number.MAX_SAFE_INTEGER;
     }
     if (typeof options.precision === "undefined") {
       options.precision = 1;


### PR DESCRIPTION
Hey, my team has been using `faker.js` for a while and really love it. We had a discussion internally about `faker.random.number` and noticed the max was `99999` and talked about using it like this instead for safety. 

```javascript
faker.random.number({ max: Number.MAX_SAFE_INTEGER });
```

I suggested that we try and update the default here so we can avoid that potentially multiple times in out codebase. 

No strong opinion here if there was reasons for going with `99999` originally. 

**Note** I took a look at the unit tests and noticed there was no test for the default max value so I wasn't sure how to add a test for it here.