### PR TITLE
correct dobra code and symbol

### DIFF
--- a/lib/locales/en/finance/currency.js
+++ b/lib/locales/en/finance/currency.js
@@ -504,8 +504,8 @@ module["exports"] = {
     "symbol": "$"
   },
   "Dobra": {
-    "code": "STD",
-    "symbol": ""
+    "code": "STN",
+    "symbol": "Db"
   },
   "El Salvador Colon US Dollar": {
     "code": "SVC USD",


### PR DESCRIPTION
According to the following sources, STN is the ISO code of dobra:
* https://en.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9_and_Pr%C3%ADncipe_dobra
* https://www.xe.com/currency/stn-sao-tomean-dobra