### PR TITLE
add transaction description method on finance module

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -292,6 +292,22 @@ var Finance = function (faker) {
           prob < 40 ?
               Helpers.replaceSymbols("###") : "");
   };
+
+  /**
+   * description
+   *
+   * @method  faker.finance.transactionDescription
+   */
+  self.transactionDescription = function() {
+    var account = Helpers.createTransaction().account
+    var card = faker.finance.mask();
+    var currency = faker.finance.currencyCode();
+    var amount = Helpers.createTransaction().amount
+    var transactionType = Helpers.createTransaction().type
+    var company = Helpers.createTransaction().business
+    return transactionType + " transaction at " + company + " using card ending with ***" + card + " for " + currency + " " + amount + " in account ***" + account
+  }
+
 };
 
 module['exports'] = Finance;

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -342,4 +342,12 @@ describe('finance.js', function () {
             assert.ok(bic.match(expr));
         });
     });
+
+    describe("transactionDescription()", function() {
+			it("returns a random transaction description", function() {
+				var transactionDescription = faker.finance.transactionDescription();
+
+				assert.ok(transactionDescription);
+			})
+    })
 });


### PR DESCRIPTION
#773 
 The new transaction description method on faker.finance will allow something like this
```
faker.finance.transactionDescription();
=> "deposit transaction at Jacobs, Tremblay and Gorczany using card ending with ***5331 for EGP 141.20 in account ***03287186"
```
successfully ran `gulp` and `mocha`

open for further improvements 👍🏻