### PR TITLE
Fixed issue where `useAbbr` parameter not used.

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -207,7 +207,9 @@ function Address (faker) {
    * @param {Boolean} useAbbr
    */
   this.state = function (useAbbr) {
-      return faker.random.arrayElement(faker.definitions.address.state);
+      return useAbbr
+        ? faker.random.arrayElement(faker.definitions.address.state_abbr)
+        : faker.random.arrayElement(faker.definitions.address.state);
   }
 
   /**

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -225,6 +225,12 @@ describe("address.js", function () {
             assert.ok(faker.address.state.called);
             faker.address.state.restore();
         });
+
+        it("returns abbreviation when useAbbr is true", function () {
+            var state = faker.address.state(true);
+            assert.equal(typeof state, 'string');
+            assert.equal(state.length <= 2, true);
+        })
     });
 
     describe("zipCode()", function () {


### PR DESCRIPTION
It will now return an abbreviated state if `useAbbr` is true.