### PR TITLE
fr/address/city_name.js: fix typo in "Lille" name

### DIFF
--- a/lib/locales/fr/address/city_name.js
+++ b/lib/locales/fr/address/city_name.js
@@ -8,7 +8,7 @@ module["exports"] = [
   "Strasbourg",
   "Montpellier",
   "Bordeaux",
-  "Lille13",
+  "Lille",
   "Rennes",
   "Reims",
   "Le Havre",


### PR DESCRIPTION
"Lille" is the real city name, not "Lille13".