### PR TITLE
Czech Republic

### DIFF
--- a/lib/locales/tr/address/country.js
+++ b/lib/locales/tr/address/country.js
@@ -40,7 +40,7 @@ module["exports"] = [
   "Christmas Adası , Avusturalya",
   "Cibuti",
   "Çad",
-  "Çek Cumhuriyeti",
+  "Çekya",
   "Çin",
   "Danimarka",
   "Doğu Timor",


### PR DESCRIPTION
Czech Republic changed its names from "Çek Cumhuriyeti" to "Çekya".
For more info:
https://tr.wikipedia.org/wiki/%C3%87ek_Cumhuriyeti