### PR TITLE
Change image url to stable provider

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -47,7 +47,7 @@ var Image = function (faker) {
       if (typeof https !== 'undefined' && https === true) {
         protocol = 'https://';
       }
-      var url = protocol + 'lorempixel.com/' + width + '/' + height;
+      var url = protocol + 'placeimg.com/' + width + '/' + height;
       if (typeof category !== 'undefined') {
         url += '/' + category;
       }


### PR DESCRIPTION
It could just be my ISP, but I have had a lot of trouble loading images from lorempixel.com. This changes the base url for the image request from lorempixel.com to placeimg.com, which share the same url structure when querying for random images.