### PR TITLE
Fix return of finance.amount

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -110,8 +110,9 @@ var Finance = function (faker) {
       dec = dec === undefined ? 2 : dec;
       symbol = symbol || '';
       var randValue = faker.random.number({ max: max, min: min, precision: Math.pow(10, -dec) });
+      var stringNumber = symbol + randValue.toFixed(dec);
 
-      return symbol + randValue.toFixed(dec);
+      return Number(stringNumber);
   };
 
   /**

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -160,9 +160,9 @@ describe('finance.js', function () {
 
         });
 
-        it("should use the defaul decimal location when not passing arguments", function () {
+        it("should use the default decimal location when not passing arguments", function () {
 
-            var amount = faker.finance.amount();
+            var amount = faker.finance.amount().toString();
 
             var decimal = '.';
             var expected = amount.length - 3;
@@ -200,7 +200,7 @@ describe('finance.js', function () {
             var amount = faker.finance.amount(100, 100, 1);
 
             assert.ok(amount);
-            assert.strictEqual(amount , '100.0', "the amount should be equal 100.0");
+            assert.strictEqual(amount , 100.0, "the amount should be equal 100.0");
         });
 
         it("it should handle argument dec = 0", function () {
@@ -208,7 +208,17 @@ describe('finance.js', function () {
             var amount = faker.finance.amount(100, 100, 0);
 
             assert.ok(amount);
-            assert.strictEqual(amount , '100', "the amount should be equal 100");
+            assert.strictEqual(amount , 100, "the amount should be equal 100");
+        });
+
+        it("it should return a number", function() {
+
+            var amount = faker.finance.amount(100, 100, 0);
+
+            var typeOfAmount = typeof amount;
+
+            assert.ok(amount);
+            assert.strictEqual(typeOfAmount , 'number', "the amount type should be number");
         });
 
     });


### PR DESCRIPTION
How @amartiuz said on issue #884 , the function `faker.finance.amount()` was returning a `string` instead of a `number`, sometimes this can cause a problem and don't make sense the function returns a string. This PR fixes this.

Behavior before of this changes: returns a string. ie: "122.12"
Behavior after of this changes: returns a number. ie: 122.12 