### PR TITLE
Add multi parameters support for faker.fake

### DIFF
--- a/lib/fake.js
+++ b/lib/fake.js
@@ -88,6 +88,8 @@ function Fake (faker) {
     var result;
     if (typeof params === "string" && params.length === 0) {
       result = fn.call(this);
+    } else if (typeof params === "string" && params.indexOf(',') !== -1) {
+      result = fn.apply(this, params.split(','));
     } else {
       result = fn.call(this, params);
     }


### PR DESCRIPTION
This PR addresses #842 

Since I couldn't find anything that transpile the code from es6 to es5, I used `fn.apply` with array instead of a `spread` to pass N parameters to the interpolated function.

Also to not break other implementations, I decided to add a `else if` validating if `params` is a string and has a comma in it.