### PR TITLE
Removed redundant } in nl_BE city names

### DIFF
--- a/lib/locales/nl_BE/address/city.js
+++ b/lib/locales/nl_BE/address/city.js
@@ -1,4 +1,4 @@
 module["exports"] = [
   "#{city_prefix}",
-  "#{city_prefix}}#{city_suffix}"
+  "#{city_prefix}#{city_suffix}"
 ];


### PR DESCRIPTION
Fixed an issue for the nl_BE locale. The City names get generated with a } between them if they're a compound of city_prefix and city_suffix.