### PR TITLE
Fix: Make faker.random.word return always only one word

### DIFF
--- a/build/build/faker.js
+++ b/build/build/faker.js
@@ -69926,7 +69926,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/az/faker.az.js
+++ b/build/build/locales/az/faker.az.js
@@ -20582,7 +20582,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/cz/faker.cz.js
+++ b/build/build/locales/cz/faker.cz.js
@@ -32744,7 +32744,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/de/faker.de.js
+++ b/build/build/locales/de/faker.de.js
@@ -22458,7 +22458,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/de_AT/faker.de_AT.js
+++ b/build/build/locales/de_AT/faker.de_AT.js
@@ -21712,7 +21712,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/de_CH/faker.de_CH.js
+++ b/build/build/locales/de_CH/faker.de_CH.js
@@ -18782,7 +18782,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en/faker.en.js
+++ b/build/build/locales/en/faker.en.js
@@ -18096,7 +18096,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_AU/faker.en_AU.js
+++ b/build/build/locales/en_AU/faker.en_AU.js
@@ -18744,7 +18744,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_BORK/faker.en_BORK.js
+++ b/build/build/locales/en_BORK/faker.en_BORK.js
@@ -18214,7 +18214,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_CA/faker.en_CA.js
+++ b/build/build/locales/en_CA/faker.en_CA.js
@@ -18202,7 +18202,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_GB/faker.en_GB.js
+++ b/build/build/locales/en_GB/faker.en_GB.js
@@ -18250,7 +18250,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_IE/faker.en_IE.js
+++ b/build/build/locales/en_IE/faker.en_IE.js
@@ -18227,7 +18227,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_IND/faker.en_IND.js
+++ b/build/build/locales/en_IND/faker.en_IND.js
@@ -19120,7 +19120,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_US/faker.en_US.js
+++ b/build/build/locales/en_US/faker.en_US.js
@@ -18484,7 +18484,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/en_au_ocker/faker.en_au_ocker.js
+++ b/build/build/locales/en_au_ocker/faker.en_au_ocker.js
@@ -18447,7 +18447,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/es/faker.es.js
+++ b/build/build/locales/es/faker.es.js
@@ -20104,7 +20104,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/es_MX/faker.es_MX.js
+++ b/build/build/locales/es_MX/faker.es_MX.js
@@ -20963,7 +20963,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/fa/faker.fa.js
+++ b/build/build/locales/fa/faker.fa.js
@@ -18990,7 +18990,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/fr/faker.fr.js
+++ b/build/build/locales/fr/faker.fr.js
@@ -18748,7 +18748,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/fr_CA/faker.fr_CA.js
+++ b/build/build/locales/fr_CA/faker.fr_CA.js
@@ -18190,7 +18190,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/ge/faker.ge.js
+++ b/build/build/locales/ge/faker.ge.js
@@ -19900,7 +19900,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/id_ID/faker.id_ID.js
+++ b/build/build/locales/id_ID/faker.id_ID.js
@@ -21011,7 +21011,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/it/faker.it.js
+++ b/build/build/locales/it/faker.it.js
@@ -19587,7 +19587,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/ja/faker.ja.js
+++ b/build/build/locales/ja/faker.ja.js
@@ -18336,7 +18336,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/ko/faker.ko.js
+++ b/build/build/locales/ko/faker.ko.js
@@ -18498,7 +18498,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/nb_NO/faker.nb_NO.js
+++ b/build/build/locales/nb_NO/faker.nb_NO.js
@@ -18733,7 +18733,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/nep/faker.nep.js
+++ b/build/build/locales/nep/faker.nep.js
@@ -18354,7 +18354,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/nl/faker.nl.js
+++ b/build/build/locales/nl/faker.nl.js
@@ -18704,7 +18704,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/pl/faker.pl.js
+++ b/build/build/locales/pl/faker.pl.js
@@ -20586,7 +20586,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/pt_BR/faker.pt_BR.js
+++ b/build/build/locales/pt_BR/faker.pt_BR.js
@@ -18679,7 +18679,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/ru/faker.ru.js
+++ b/build/build/locales/ru/faker.ru.js
@@ -19669,7 +19669,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/sk/faker.sk.js
+++ b/build/build/locales/sk/faker.sk.js
@@ -20947,7 +20947,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/sv/faker.sv.js
+++ b/build/build/locales/sv/faker.sv.js
@@ -18818,7 +18818,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/tr/faker.tr.js
+++ b/build/build/locales/tr/faker.tr.js
@@ -19627,7 +19627,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/uk/faker.uk.js
+++ b/build/build/locales/uk/faker.uk.js
@@ -19850,7 +19850,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/vi/faker.vi.js
+++ b/build/build/locales/vi/faker.vi.js
@@ -18569,7 +18569,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/zh_CN/faker.zh_CN.js
+++ b/build/build/locales/zh_CN/faker.zh_CN.js
@@ -18552,7 +18552,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/build/build/locales/zh_TW/faker.zh_TW.js
+++ b/build/build/locales/zh_TW/faker.zh_TW.js
@@ -18475,7 +18475,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/js/faker.js
+++ b/examples/browser/js/faker.js
@@ -69926,7 +69926,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/az/faker.az.js
+++ b/examples/browser/locales/az/faker.az.js
@@ -20582,7 +20582,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/cz/faker.cz.js
+++ b/examples/browser/locales/cz/faker.cz.js
@@ -32744,7 +32744,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/de/faker.de.js
+++ b/examples/browser/locales/de/faker.de.js
@@ -22458,7 +22458,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/de_AT/faker.de_AT.js
+++ b/examples/browser/locales/de_AT/faker.de_AT.js
@@ -21712,7 +21712,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/de_CH/faker.de_CH.js
+++ b/examples/browser/locales/de_CH/faker.de_CH.js
@@ -18782,7 +18782,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en/faker.en.js
+++ b/examples/browser/locales/en/faker.en.js
@@ -18096,7 +18096,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_AU/faker.en_AU.js
+++ b/examples/browser/locales/en_AU/faker.en_AU.js
@@ -18744,7 +18744,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_BORK/faker.en_BORK.js
+++ b/examples/browser/locales/en_BORK/faker.en_BORK.js
@@ -18214,7 +18214,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_CA/faker.en_CA.js
+++ b/examples/browser/locales/en_CA/faker.en_CA.js
@@ -18202,7 +18202,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_GB/faker.en_GB.js
+++ b/examples/browser/locales/en_GB/faker.en_GB.js
@@ -18250,7 +18250,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_IE/faker.en_IE.js
+++ b/examples/browser/locales/en_IE/faker.en_IE.js
@@ -18227,7 +18227,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_IND/faker.en_IND.js
+++ b/examples/browser/locales/en_IND/faker.en_IND.js
@@ -19120,7 +19120,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_US/faker.en_US.js
+++ b/examples/browser/locales/en_US/faker.en_US.js
@@ -18484,7 +18484,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/en_au_ocker/faker.en_au_ocker.js
+++ b/examples/browser/locales/en_au_ocker/faker.en_au_ocker.js
@@ -18447,7 +18447,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/es/faker.es.js
+++ b/examples/browser/locales/es/faker.es.js
@@ -20104,7 +20104,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/es_MX/faker.es_MX.js
+++ b/examples/browser/locales/es_MX/faker.es_MX.js
@@ -20963,7 +20963,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/fa/faker.fa.js
+++ b/examples/browser/locales/fa/faker.fa.js
@@ -18990,7 +18990,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/fr/faker.fr.js
+++ b/examples/browser/locales/fr/faker.fr.js
@@ -18748,7 +18748,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/fr_CA/faker.fr_CA.js
+++ b/examples/browser/locales/fr_CA/faker.fr_CA.js
@@ -18190,7 +18190,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/ge/faker.ge.js
+++ b/examples/browser/locales/ge/faker.ge.js
@@ -19900,7 +19900,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/id_ID/faker.id_ID.js
+++ b/examples/browser/locales/id_ID/faker.id_ID.js
@@ -21011,7 +21011,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/it/faker.it.js
+++ b/examples/browser/locales/it/faker.it.js
@@ -19587,7 +19587,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/ja/faker.ja.js
+++ b/examples/browser/locales/ja/faker.ja.js
@@ -18336,7 +18336,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/ko/faker.ko.js
+++ b/examples/browser/locales/ko/faker.ko.js
@@ -18498,7 +18498,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/nb_NO/faker.nb_NO.js
+++ b/examples/browser/locales/nb_NO/faker.nb_NO.js
@@ -18733,7 +18733,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/nep/faker.nep.js
+++ b/examples/browser/locales/nep/faker.nep.js
@@ -18354,7 +18354,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/nl/faker.nl.js
+++ b/examples/browser/locales/nl/faker.nl.js
@@ -18704,7 +18704,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/pl/faker.pl.js
+++ b/examples/browser/locales/pl/faker.pl.js
@@ -20586,7 +20586,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/pt_BR/faker.pt_BR.js
+++ b/examples/browser/locales/pt_BR/faker.pt_BR.js
@@ -18679,7 +18679,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/ru/faker.ru.js
+++ b/examples/browser/locales/ru/faker.ru.js
@@ -19669,7 +19669,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/sk/faker.sk.js
+++ b/examples/browser/locales/sk/faker.sk.js
@@ -20947,7 +20947,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/sv/faker.sv.js
+++ b/examples/browser/locales/sv/faker.sv.js
@@ -18818,7 +18818,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/tr/faker.tr.js
+++ b/examples/browser/locales/tr/faker.tr.js
@@ -19627,7 +19627,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/uk/faker.uk.js
+++ b/examples/browser/locales/uk/faker.uk.js
@@ -19850,7 +19850,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/vi/faker.vi.js
+++ b/examples/browser/locales/vi/faker.vi.js
@@ -18569,7 +18569,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/zh_CN/faker.zh_CN.js
+++ b/examples/browser/locales/zh_CN/faker.zh_CN.js
@@ -18552,7 +18552,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/examples/browser/locales/zh_TW/faker.zh_TW.js
+++ b/examples/browser/locales/zh_TW/faker.zh_TW.js
@@ -18475,7 +18475,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -202,7 +202,7 @@ function Random (faker, seed) {
 
     // randomly pick from the many faker methods that can generate words
     var randomWordMethod = faker.random.arrayElement(wordMethods);
-    return faker.fake('{{' + randomWordMethod + '}}');
+    return faker.fake('{{' + randomWordMethod + '}}').split(' ').join('');
 
   }
 


### PR DESCRIPTION
The method faker.random.word() can return multiple words sometimes (due to its behavior). To prevent that, I cut all spaces between the strings, joining them into one before returning.

Fixes #602 
Fixes #661  