### PR TITLE
Update code of merit url in CODE_OF_MERIT.MD

### DIFF
--- a/CODE_OF_MERIT.MD
+++ b/CODE_OF_MERIT.MD
@@ -6,10 +6,10 @@ of the project, technical or otherwise, including overruling previous decisions.
 There are no limitations to this decisional power.
 
 2. Contributions are an expected result of your membership on the project.
-Don't expect others to do your work or help you with your work forever. 
+Don't expect others to do your work or help you with your work forever.
 
 3. All members have the same opportunities to seek any challenge they want
-within the project. 
+within the project.
 
 4. Authority or position in the project will be proportional
 to the accrued contribution. Seniority must be earned.
@@ -39,8 +39,8 @@ of the originator to provide requested context.
 in the scope of the project. This Code of Merit does not take precedence over
 governing law.
 
-12. This Code of Merit governs the technical procedures of the project not the 
-activities outside of it. 
+12. This Code of Merit governs the technical procedures of the project not the
+activities outside of it.
 
 13. Participation on the project equates to agreement of this Code of Merit.
 
@@ -49,4 +49,4 @@ to the project. Any intent to deviate the project from its original purpose
 of existence will constitute grounds for remedial action which may include
 expulsion from the project.
 
-This document is the Code of Merit (http://code-of-merit.org), version 1.0.
+This document is the Code of Merit (https://codeofmerit.org/), version 1.0.


### PR DESCRIPTION
url to document  is wrong ( redirect to Mayan EDMS page)

The Code of Merit used to be mantained by its original author but he discontinued every one of his projects except for Mayan EDMS. This website is an attempt to keep the Code of Merit available.