### PR TITLE
Add optional country code parameter for iban method

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -255,8 +255,14 @@ self.litecoinAddress = function () {
    * @method  faker.finance.iban
    */
   self.iban = function (formatted, countryCode) {
-      var findFormat = function(currentFormat) { return currentFormat.country === countryCode; };
-      var ibanFormat = countryCode ? ibanLib.formats.find(findFormat) : faker.random.arrayElement(ibanLib.formats);
+      var ibanFormat;
+      if (countryCode) {
+          var findFormat = function(currentFormat) { return currentFormat.country === countryCode; };
+          ibanFormat = ibanLib.formats.find(findFormat);
+      } else {
+          ibanFormat = faker.random.arrayElement(ibanLib.formats);
+      }
+
       if (!ibanFormat) {
           throw new Error('Country code ' + countryCode + ' not supported.');
       }

--- a/lib/finance.js
+++ b/lib/finance.js
@@ -248,10 +248,19 @@ self.litecoinAddress = function () {
   /**
    * iban
    *
+   * @param {boolean} [formatted=false] - Return a formatted version of the generated IBAN.
+   * @param {string} [countryCode] - The country code from which you want to generate an IBAN, if none is provided a random country will be used.
+   * @throws Will throw an error if the passed country code is not supported.
+   *
    * @method  faker.finance.iban
    */
-  self.iban = function (formatted) {
-      var ibanFormat = faker.random.arrayElement(ibanLib.formats);
+  self.iban = function (formatted, countryCode) {
+      var findFormat = function(currentFormat) { return currentFormat.country === countryCode; };
+      var ibanFormat = countryCode ? ibanLib.formats.find(findFormat) : faker.random.arrayElement(ibanLib.formats);
+      if (!ibanFormat) {
+          throw new Error('Country code ' + countryCode + ' not supported.');
+      }
+
       var s = "";
       var count = 0;
       for (var b = 0; b < ibanFormat.bban.length; b++) {

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -352,6 +352,17 @@ describe('finance.js', function () {
 
             assert.equal(ibanLib.mod97(ibanLib.toDigitString(bban)), 1, "the result should be equal to 1");
         });
+        it("returns a specific and formally correct IBAN number", function () {
+            var iban = faker.finance.iban(false, "DE");
+            var bban = iban.substring(4) + iban.substring(0, 4);
+            var countryCode = iban.substring(0, 2);
+
+            assert.equal(countryCode, "DE");
+            assert.equal(ibanLib.mod97(ibanLib.toDigitString(bban)), 1, "the result should be equal to 1");
+        });
+        it("throws an error if the passed country code is not supported", function () {
+            assert.throws(function() { faker.finance.iban(false, 'AA');}, /Country code AA not supported/);
+        });
     });
 
     describe("bic()", function () {


### PR DESCRIPTION
We have a few integration tests running where we need an IBAN from a specific country, but the `iban` method always returned a random one. 

This PR adds a second (optional) parameter to the `iban` method where you can pass the country from which you want to generate an IBAN