### PR TITLE
Fix return of finance.amount to string

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -112,7 +112,7 @@ var Finance = function (faker) {
       var randValue = faker.random.number({ max: max, min: min, precision: Math.pow(10, -dec) });
       var stringNumber = symbol + randValue.toFixed(dec);
 
-      return Number(stringNumber);
+      return symbol + randValue.toFixed(dec);
   };
 
   /**

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -161,19 +161,18 @@ describe('finance.js', function () {
 
         });
 
-        /*
-        Remark: This needs to be fixed now see: https://github.com/Marak/faker.js/issues/984
         it("should use the default decimal location when not passing arguments", function () {
 
-            var amount = faker.finance.amount().toString();
+            var amount = faker.finance.amount();
 
             var decimal = '.';
             var expected = amount.length - 3;
-            var actual = amount.indexOf(decimal);
+            var amount = faker.finance.amount(100, 100, 1);
 
-            assert.equal(actual, expected, 'The expected location of the decimal is ' + expected + ' but it was ' + actual + ' amount ' + amount);
+            assert.ok(amount);
+            assert.strictEqual(amount , '100.0', "the amount should be equal 100.0");
         });
-        */
+        
         //TODO: add support for more currency and decimal options
         it("should not include a currency symbol by default", function () {
 
@@ -203,7 +202,7 @@ describe('finance.js', function () {
             var amount = faker.finance.amount(100, 100, 1);
 
             assert.ok(amount);
-            assert.strictEqual(amount , 100.0, "the amount should be equal 100.0");
+            assert.strictEqual(amount , "100.0", "the amount should be equal 100.0");
         });
 
         it("it should handle argument dec = 0", function () {
@@ -211,17 +210,17 @@ describe('finance.js', function () {
             var amount = faker.finance.amount(100, 100, 0);
 
             assert.ok(amount);
-            assert.strictEqual(amount , 100, "the amount should be equal 100");
+            assert.strictEqual(amount , '100', "the amount should be equal 100");
         });
 
-        it("it should return a number", function() {
+        it("it should return a string", function() {
 
             var amount = faker.finance.amount(100, 100, 0);
 
             var typeOfAmount = typeof amount;
 
             assert.ok(amount);
-            assert.strictEqual(typeOfAmount , 'number', "the amount type should be number");
+            assert.strictEqual(typeOfAmount , "string", "the amount type should be number");
         });
 
     });


### PR DESCRIPTION
On issue #984, it was said that the function faker.finance.amount() was returning a number instead of a string. This PR fixes this.

Behavior before of this changes: returns a number. ie: 
```js
faker.finance.amount()
faker.finance.amount()
faker.finance.amount()

95.15
669.55
550.8
```

Behavior after of this changes: returns a string. ie:
```js
faker.finance.amount()
faker.finance.amount()
faker.finance.amount()

"95.15"
"669.55"
"550.80"
```