### PR TITLE
adds optional parameters to .url, docs, and tests

### DIFF
--- a/doc/faker.internet.html
+++ b/doc/faker.internet.html
@@ -33,7 +33,7 @@
 			<li class="dropdown">
 				<a href="namespaces.list.html" class="dropdown-toggle" data-toggle="dropdown">Namespaces<b class="caret"></b></a>
 				<ul class="dropdown-menu ">
-					<li><a href="faker.html">faker</a></li><li><a href="faker.address.html">faker.address</a></li><li><a href="faker.commerce.html">faker.commerce</a></li><li><a href="faker.company.html">faker.company</a></li><li><a href="faker.database.html">faker.database</a></li><li><a href="faker.date.html">faker.date</a></li><li><a href="faker.finance.html">faker.finance</a></li><li><a href="faker.git.html">faker.git</a></li><li><a href="faker.hacker.html">faker.hacker</a></li><li><a href="faker.helpers.html">faker.helpers</a></li><li><a href="faker.image.html">faker.image</a></li><li><a href="faker.image.lorempicsum.html">faker.image.lorempicsum</a></li><li><a href="faker.image.lorempixel.html">faker.image.lorempixel</a></li><li><a href="faker.image.unsplash.html">faker.image.unsplash</a></li><li><a href="faker.internet.html">faker.internet</a></li><li><a href="faker.lorem.html">faker.lorem</a></li><li><a href="faker.name.html">faker.name</a></li><li><a href="faker.phone.html">faker.phone</a></li><li><a href="faker.random.html">faker.random</a></li><li><a href="faker.system.html">faker.system</a></li><li><a href="faker.time.html">faker.time</a></li><li><a href="faker.unique.html">faker.unique</a></li><li><a href="faker.vehicle.html">faker.vehicle</a></li>
+					<li><a href="faker.html">faker</a></li><li><a href="faker.address.html">faker.address</a></li><li><a href="faker.commerce.html">faker.commerce</a></li><li><a href="faker.company.html">faker.company</a></li><li><a href="faker.database.html">faker.database</a></li><li><a href="faker.date.html">faker.date</a></li><li><a href="faker.finance.html">faker.finance</a></li><li><a href="faker.git.html">faker.git</a></li><li><a href="faker.hacker.html">faker.hacker</a></li><li><a href="faker.helpers.html">faker.helpers</a></li><li><a href="faker.image.html">faker.image</a></li><li><a href="faker.image.lorempicsum.html">faker.image.lorempicsum</a></li><li><a href="faker.image.lorempixel.html">faker.image.lorempixel</a></li><li><a href="faker.image.unsplash.html">faker.image.unsplash</a></li><li><a href="faker.internet.html">faker.internet</a></li><li><a href="faker.lorem.html">faker.lorem</a></li><li><a href="faker.music.html">faker.music</a></li><li><a href="faker.name.html">faker.name</a></li><li><a href="faker.phone.html">faker.phone</a></li><li><a href="faker.random.html">faker.random</a></li><li><a href="faker.system.html">faker.system</a></li><li><a href="faker.time.html">faker.time</a></li><li><a href="faker.unique.html">faker.unique</a></li><li><a href="faker.vehicle.html">faker.vehicle</a></li>
 				</ul>
 			</li>
 			
@@ -2911,7 +2911,7 @@
             
 <hr>
 <dt>
-    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url()</h4>
+    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url(protocol, domainName)</h4>
     
     
 </dt>
@@ -2928,6 +2928,80 @@
     
 
     
+    
+        <h5>Parameters:</h5>
+        
+
+<table class="params table table-striped">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>protocol</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>domainName</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
     
 
     
@@ -2989,7 +3063,7 @@
             
 <hr>
 <dt>
-    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url()</h4>
+    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url(protocol, domainName)</h4>
     
     
 </dt>
@@ -3006,6 +3080,80 @@
     
 
     
+    
+        <h5>Parameters:</h5>
+        
+
+<table class="params table table-striped">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>protocol</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>domainName</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
     
 
     
@@ -6375,7 +6523,7 @@
             
 <hr>
 <dt>
-    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url()</h4>
+    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url(protocol, domainName)</h4>
     
     
 </dt>
@@ -6392,6 +6540,80 @@
     
 
     
+    
+        <h5>Parameters:</h5>
+        
+
+<table class="params table table-striped">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>protocol</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>domainName</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
     
 
     
@@ -6453,7 +6675,7 @@
             
 <hr>
 <dt>
-    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url()</h4>
+    <h4 class="name" id=".url"><span class="type-signature">&lt;static> </span>url(protocol, domainName)</h4>
     
     
 </dt>
@@ -6470,6 +6692,80 @@
     
 
     
+    
+        <h5>Parameters:</h5>
+        
+
+<table class="params table table-striped">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>protocol</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>domainName</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">string</span>
+
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
     
 
     
@@ -7037,7 +7333,7 @@
 <span class="jsdoc-message">
 	Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.6.5</a>
 	
-		on 2020-08-26T18:35:42-04:00
+		on 2020-09-06T18:31:53-07:00
 	
 	using the <a href="https://github.com/docstrap/docstrap">DocStrap template</a>.
 </span>

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -135,9 +135,17 @@ var Internet = function (faker) {
    * url
    *
    * @method faker.internet.url
+   * @param {string} protocol
+   * @param {string} domainName
    */
-  self.url = function () {
-      return faker.internet.protocol() + '://' + faker.internet.domainName();
+  self.url = function (protocol, domainName) {
+      if (!protocol) {
+          protocol = faker.internet.protocol();
+      }
+      if (!domainName) {
+          domainName = faker.internet.domainName();
+      }
+      return protocol + '://' + domainName;
   };
 
   self.url.schema = {

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -136,6 +136,12 @@ describe("internet.js", function () {
             assert.ok(url);
             assert.strictEqual(url,'http://bar.net');
         });
+        it('returns a url with protocol and domainName specified ', function () {
+            var url = faker.internet.url('https', 'foo.com');
+
+            assert.ok(url);
+            assert.strictEqual(url,'https://foo.com');
+        });
     });
 
     describe("ip()", function () {


### PR DESCRIPTION
This PR adds optional parameters to `internet.url()`, inspired by similar functionality in [the ruby `faker` gem](https://www.rubydoc.info/github/stympy/faker/Faker%2FInternet.url)

This is convenient, for example, when:
* wanting to generate only secure URLs, with randomized domain names
* wanting to generate only insecure (HTTP) URLs, with randomized domain names
* wanting to generate a mix of HTTPS and HTTP urls, all with the same domain name