### PR TITLE
Fix: internet email for japanese and chinese characters

### DIFF
--- a/examples/node/singleLocale.js
+++ b/examples/node/singleLocale.js
@@ -1,7 +1,7 @@
-var faker = require('../locale/en');
+var faker = require('../../locale/en');
 
 console.log(faker.name.findName());
 
-var faker = require('../locale/uk');
+var faker = require('../../locale/uk');
 
 console.log(faker.name.findName());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ var Helpers = function (faker) {
    */
   self.slugify = function (string) {
       string = string || "";
-      return string.replace(/ /g, '-').replace(/[^\w\.\-]+/g, '');
+      return string.replace(/ /g, '-').replace(/[^\一-龠\ぁ-ゔ\ァ-ヴー\w\.\-]+/g, '');
   };
 
   /**

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -14,6 +14,15 @@ describe("internet.js", function () {
             assert.equal(res, 'Aiden.Harann55');
             faker.internet.userName.restore();
         });
+
+        it("returns an email with japanese characters", function () {
+            sinon.stub(faker.internet, 'userName').returns('思源_唐3');
+            var email = faker.internet.email("思源_唐3");
+            var res = email.split("@");
+            res = res[0];
+            assert.equal(res, '思源_唐3');
+            faker.internet.userName.restore();
+        });
     });
 
     describe("exampleEmail", function () {


### PR DESCRIPTION
Closes #943

This PR fixes the internet email for `ja` and `ch` locales, which was returning invalid emails.

Also, I fix the node examples because it had a wrong import path.
