### PR TITLE
Add method to generate port numbers

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -240,6 +240,20 @@ var Internet = function (faker) {
   };
 
   /**
+   * port
+   * 
+   * @method faker.internet.port
+   */
+  self.port = function() {
+    return faker.random.number({ min: 0, max: 65535 });
+  };
+
+  self.port.schema = {
+    "description": "Generates a random port number.",
+    "sampleResults": ["4422"]
+  };
+
+  /**
    * userAgent
    *
    * @method faker.internet.userAgent

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -154,6 +154,14 @@ describe("internet.js", function () {
         });
     });
 
+    describe("port()", function () {
+        it("returns a random port number", function () {
+            var port = faker.internet.port();
+            assert.ok(Number.isInteger(port));
+            assert.ok(0 <= port && port <= 65535);
+        });
+    });
+
     describe("userAgent()", function () {
         it("returns a valid user-agent", function () {
             var ua = faker.internet.userAgent();


### PR DESCRIPTION
This pull request provides a convenient way to generate port numbers.

Linking the port number specification: https://tools.ietf.org/html/rfc6335#section-6