### PR TITLE
fix: reduce size of the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,15 @@ examples/
 meteor/
 test/
 logo.png
+.DS_Store
+reports/
+.github/
+.nyc_output/
+*.yml
+.versions
+*.png
+*.lock
+.jshint*
+gulpfile.js
+CONTRIBUTING.md
+CODE_OF_MERIT.MD


### PR DESCRIPTION
Updated `.npmignore` file to include files that are not necessary in the bundle.

Package size difference:

**Before**:
```
npm notice package size:  6.1 MB
npm notice unpacked size: 43.5 MB
npm notice total files:   4692
```

**After**:
```
npm notice package size:  1.9 MB
npm notice unpacked size: 8.4 MB
npm notice total files:   1585
```

This should not affect anyone in a negative way and for everyone it will improve install times :)