### PR TITLE
Fix wrong naming of first name variables in the Norwegian locale

### DIFF
--- a/lib/locales/nb_NO/name/index.js
+++ b/lib/locales/nb_NO/name/index.js
@@ -1,8 +1,8 @@
 var name = {};
 module['exports'] = name;
 name.first_name = require("./first_name");
-name.feminine_name = require("./feminine_name");
-name.masculine_name = require("./masculine_name");
+name.female_first_name = require("./feminine_name");
+name.male_first_name = require("./masculine_name");
 name.last_name = require("./last_name");
 name.prefix = require("./prefix");
 name.suffix = require("./suffix");


### PR DESCRIPTION
`faker.name.findName()` was generating English first names and Norwegian last names, when nb_NO is specified as locale. I think this is due to the expected property names in lib/name.js. The Norwegian locale file uses `feminine_name` and `masculine_name`. Renaming the properties to `female_first_name` and `male_first_name` worked.

Can be reproed with:

```html
<!DOCTYPE html>
<html lang="">
  <head>
  <script src = "faker.js/dist/faker.js" type = "text/javascript"></script>
    <script>
      faker.locale = "nb_NO";
      console.log(faker.name.findName())
    </script>
    <meta charset="utf-8">
    <title>Testing Norwegian names</title>
  </head>
  <body></body>
</html>
```