### PR TITLE
Bug Fix: Corrected reference to af_ZA & zu_ZA.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@
 ## Usage
 
 ### Browser
+
 ```html
     <script src = "faker.js" type = "text/javascript"></script>
     <script>
@@ -24,7 +25,9 @@
       var randomCard = faker.helpers.createCard(); // random contact card containing many properties
     </script>
 ```
+
 ### Node.js
+
 ```js
     var faker = require('faker');
 
@@ -32,6 +35,7 @@
     var randomEmail = faker.internet.email(); // Kassandra.Haley@erich.biz
     var randomCard = faker.helpers.createCard(); // random contact card containing many properties
 ```
+
 ## API
 
 ### JSDoc API Browser
@@ -195,6 +199,7 @@
 * name
   * firstName
   * lastName
+  * middleName
   * findName
   * jobTitle
   * gender
@@ -253,10 +258,12 @@ faker.js contains a super useful generator method `Faker.fake` for combining fak
 
 **Example:**
 
+
 ``` js
 console.log(faker.fake("{{name.lastName}}, {{name.firstName}} {{name.suffix}}"));
 // outputs: "Marks, Dean Sr."
 ```
+
 
 This will interpolate the format string with the value of methods `name.lastName()`, `name.firstName()`, and `name.suffix()`
 
@@ -273,6 +280,7 @@ Setting a new locale is simple:
 faker.locale = "de";
 ```
 
+ * af_ZA
  * az
  * ar
  * cz
@@ -317,6 +325,7 @@ faker.locale = "de";
  * vi
  * zh_CN
  * zh_TW
+ * zu_ZA
 
 
 ### Individual Localization Packages
@@ -351,18 +360,20 @@ console.log(firstRandom === secondRandom);
 
 ## Tests
 
-    npm install .
-    make test
+```shell
+npm install .
+make test
+```
 
 You can view a code coverage report generated in coverage/lcov-report/index.html.
 
 ## Building faker.js
 
-faker uses [gulp](http://gulpjs.com/) to automate it's build process. Each build operation is a separate task which can be run independently. 
+faker uses [gulp](http://gulpjs.com/) to automate its build process. Each build operation is a separate task which can be run independently.
 
 ### Browser Bundle
 
-```
+```shell
 npm run browser
 ```
 
@@ -370,15 +381,15 @@ npm run browser
 
 [JSDOC](https://jsdoc.app/) v3 HTML API documentation
 
-```
+```shell
 npm run jsdoc
 ```
 
 ### Building ReadMe
 
-The `ReadMe.md` file for `faker.js` is automatically generated and should not be modified directly. All updateds to `ReadMe.md` should be perfomed in `./build/src/docs.md` and then the build script should be run.
+The `ReadMe.md` file for `faker.js` is automatically generated and should not be modified directly. All updates to `ReadMe.md` should be performed in `./build/src/docs.md` and then the build script should be run.
 
-```
+```shell
 npm run readme
 ```
 
@@ -386,7 +397,7 @@ npm run readme
 
 faker.js is a popular project used by many organizations and individuals in production settings. Major and Minor version releases are generally on a monthly schedule. Bugs fixes are addressed by severity and fixed as soon as possible.
 
-If you require the absolute latest version of `faker.js` the `master` branch @ http://github.com/marak/faker.js/ should always be up to date and working.
+If you require the absolute latest version of `faker.js` the `master` branch @ <http://github.com/marak/faker.js/> should always be up to date and working.
 
 ## Maintainer
 
@@ -399,8 +410,8 @@ http://github.com/marak/faker.js/
 
 faker.js was inspired by and has used data definitions from:
 
- * https://github.com/stympy/faker/ - Copyright (c) 2007-2010 Benjamin Curtis
- * http://search.cpan.org/~jasonk/Data-Faker-0.07/ - Copyright 2004-2005 by Jason Kohles
+ * <https://github.com/stympy/faker/> - Copyright (c) 2007-2010 Benjamin Curtis
+ * <http://search.cpan.org/~jasonk/Data-Faker-0.07/> - Copyright 2004-2005 by Jason Kohles
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/locales.js
+++ b/lib/locales.js
@@ -1,3 +1,4 @@
+exports['af_ZA'] = require('./locales/af_ZA');
 exports['az'] = require('./locales/az');
 exports['ar'] = require('./locales/ar');
 exports['cz'] = require('./locales/cz');
@@ -42,3 +43,4 @@ exports['uk'] = require('./locales/uk');
 exports['vi'] = require('./locales/vi');
 exports['zh_CN'] = require('./locales/zh_CN');
 exports['zh_TW'] = require('./locales/zh_TW');
+exports['zu_ZA'] = require('./locales/zu_ZA');

--- a/lib/locales/af_ZA/index.js
+++ b/lib/locales/af_ZA/index.js
@@ -1,8 +1,9 @@
-var en_ZA = {};
-module['exports'] = en_ZA;
-en_ZA.title = "Afrikaans";
-en_ZA.address = require("./address");
-en_ZA.internet = require("./internet");
-en_ZA.phone_number = require("./phone_number");
-en_ZA.cell_phone = require("./cell_phone");
-en_ZA.company = require("./company");
+var af_ZA = {};
+module['exports'] = af_ZA;
+af_ZA.title = "Afrikaans";
+af_ZA.address = require("./address");
+af_ZA.internet = require("./internet");
+af_ZA.name = require("./name");
+af_ZA.phone_number = require("./phone_number");
+af_ZA.cell_phone = require("./cell_phone");
+af_ZA.company = require("./company");

--- a/lib/locales/zu_ZA/index.js
+++ b/lib/locales/zu_ZA/index.js
@@ -1,8 +1,9 @@
-var en_ZA = {};
-module['exports'] = en_ZA;
-en_ZA.title = "Zulu (South Africa)";
-en_ZA.address = require("./address");
-en_ZA.internet = require("./internet");
-en_ZA.phone_number = require("./phone_number");
-en_ZA.cell_phone = require("./cell_phone");
-en_ZA.company = require("./company");
+var zu_ZA = {};
+module['exports'] = zu_ZA;
+zu_ZA.title = "Zulu (South Africa)";
+zu_ZA.address = require("./address");
+zu_ZA.internet = require("./internet");
+zu_ZA.name = require("./name");
+zu_ZA.phone_number = require("./phone_number");
+zu_ZA.cell_phone = require("./cell_phone");
+zu_ZA.company = require("./company");


### PR DESCRIPTION
Hi There

A simple PR. Seems like `af_ZA` & `zu_ZA` weren't linked correctly through `locales.js`.

Sidenote: it seems a little weird having these split out into three locales (firstly as it means phone number data etc is repeated, and secondly it all references a single country and thus should have a single point of truth) I would like to propose joining them into a single `za` locale. This is done in `java-faker` under `en_ZA`. This shouldn't be a breaking change at this point, as `af_ZA` and `zu_ZA` weren't in use anyways ;)