### PR TITLE
Added support for random number generation with a fixed digit length

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -15,10 +15,10 @@ function Random (faker, seed) {
     }
   }
   /**
-   * returns a single random number based on a max number or range
+   * returns a single random number based on a max number or range or a number of digits
    *
    * @method faker.random.number
-   * @param {mixed} options {min, max, precision}
+   * @param {mixed} options {min, max, precision or digits}
    */
   this.number = function (options) {
 
@@ -30,15 +30,21 @@ function Random (faker, seed) {
 
     options = options || {};
 
-    if (typeof options.min === "undefined") {
-      options.min = 0;
-    }
-
-    if (typeof options.max === "undefined") {
-      options.max = 99999;
-    }
-    if (typeof options.precision === "undefined") {
+    if (typeof options.digits !== "undefined" && options.digits > 0 && options.digits < 15) {
+      options.min = Math.pow(10, options.digits - 1);
+      options.max = Math.pow(10, options.digits) - 1;
       options.precision = 1;
+    }
+    else {
+      if (typeof options.min === "undefined") {
+        options.min = 0;
+      }
+      if (typeof options.max === "undefined") {
+        options.max = 99999;
+      }
+      if (typeof options.precision === "undefined") {
+        options.precision = 1;
+      }
     }
 
     // Make the range inclusive of the max value
@@ -51,7 +57,7 @@ function Random (faker, seed) {
       mersenne.rand(max / options.precision, options.min / options.precision));
     // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
     randomNumber = randomNumber / (1 / options.precision);
-
+    
     return randomNumber;
 
   }

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -79,6 +79,17 @@ describe("random.js", function () {
       assert.equal(opts.max, max);
     });
 
+    it("returns a random number with a number of digits", function() {
+      for(var digits = 1; digits < 15; digits++) {
+        const options = {digits: digits};
+        for(var i = 0; i < 10; i++) {
+          var randomNumber = faker.random.number(options);
+          // check digits length
+          assert.ok(randomNumber.toString().length === digits);
+        }
+      }
+     });
+
     it('should return deterministic results when seeded with integer', function() {
       faker.seed(100);
       var name = faker.name.findName();


### PR DESCRIPTION
Added support for generating numbers with a fixed digit length (allowed digit length from 1 to 15)

`Faker.random.number({digits: 1});` -> between 1 and 9
`Faker.random.number({digits: 5});` -> between 10000 and 99999

When digits option is set min, max and precision are ignored.