### PR TITLE
Ignore coverage reports in published tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ examples/
 meteor/
 test/
 logo.png
+reports/


### PR DESCRIPTION
Upon most recent install, this takes up `36mb` of space. These coverage files are already ignored in the .gitignore and aren't needed in the module bundle. When removing these files, it additionally drops the tarball size in half:

```
$ du -h *.tgz
1.8M	faker-5.1.0-with-changes.tgz
3.6M	faker-5.1.0.tgz
```

This fixes #1049

From `CONTRIBUTING.md` guidelines:

- [x] `npm test` passes
- [x] `gulp` passes