### PR TITLE
hexaDecimal() fix: lowercase letters only and custom prefix

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -296,18 +296,22 @@ function Random (faker, seed) {
    *
    * @method faker.random.hexaDecimal
    * @param {number} count defaults to 1
+   * @prefix {string} prefix defaults to 0x
    */
-  this.hexaDecimal = function hexaDecimal(count) {
+  this.hexaDecimal = function hexaDecimal(count, prefix) {
     if (typeof count === "undefined") {
       count = 1;
     }
-
-    var wholeString = "";
-    for(var i = 0; i < count; i++) {
-      wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
+    if (typeof prefix === "undefined") {
+      prefix = "0x";
     }
 
-    return "0x"+wholeString;
+    var wholeString = prefix;
+    for(var i = 0; i < count; i++) {
+      wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]);
+    }
+
+    return wholeString;
   };
 
   return this;

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -297,7 +297,22 @@ describe("random.js", function () {
 
     it('should generate a random hex string', function() {
       var hex = hexaDecimal(5);
-      assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
+      assert.ok(hex.match(/^(0x)[0-9a-f]{5}$/i));
+    })
+
+    it('should generate a random hex string with no prefix', function() {
+      var hex = hexaDecimal(5, "");
+      assert.ok(hex.match(/^[0-9a-f]{5}$/i));
+    })
+
+    it('should generate a random hex string with a custom prefix', function() {
+      var hex = hexaDecimal(5, "hex");
+      assert.ok(hex.match(/^(hex)[0-9a-f]{5}$/i));
+    })
+
+    it('should generate a random hex string with lowercase letters and numbers only', function() {
+      var hex = hexaDecimal(500, "");
+      assert.ok(hex.match(/^[0-9a-f]{500}$/i));
     })
   })
 


### PR DESCRIPTION
`random.hexaDecimal` changes:
- removed uppercase letters for consistency. Having 'abcdef' and 'ABCDEF' was doubling the chance of getting a letter in each position as well
- added an option to have a custom (or empty) prefix. There is no need in `0x` in some cases
- updated tests