### PR TITLE
Adds random date generation function

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -164,6 +164,17 @@ var _Date = function (faker) {
       return faker.random.arrayElement(source);
   };
 
+  /**
+   * random
+   *
+   * @method faker.date.random
+   */
+  self.random = function () {
+    var date = new Date(faker.random.number());
+
+    return date
+};
+  
   return self;
 
 };

--- a/test/date.unit.js
+++ b/test/date.unit.js
@@ -115,6 +115,15 @@ describe("date.js", function () {
         });
     });
 
+    describe("random()", function () {
+        it("returns a random date", function () {
+
+            var date = faker.date.random();
+
+            assert.ok(date instanceof Date);
+        });
+    });
+
     describe("month()", function () {
         it("returns random value from date.month.wide array by default", function () {
             var month = faker.date.month();


### PR DESCRIPTION
In my codebase, I have multiple instances of this expression. 

`new Date(faker.random.number()) ` to generate a random stream of dates.

The expression is overall useful because óne can strictly require that the faked dates do not change from seed to seed. 

I found it personally to be more practical to have it on the lib side.

