### PR TITLE
[Improvement] Call `createTransaction` method once from within `finance.transactionDescription`

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -338,14 +338,15 @@ self.litecoinAddress = function () {
    * @method  faker.finance.transactionDescription
    */
   self.transactionDescription = function() {
-    var account = Helpers.createTransaction().account
+    var transaction = Helpers.createTransaction();
+    var account = transaction.account;
+    var amount = transaction.amount;
+    var transactionType = transaction.type;
+    var company = transaction.business;
     var card = faker.finance.mask();
     var currency = faker.finance.currencyCode();
-    var amount = Helpers.createTransaction().amount
-    var transactionType = Helpers.createTransaction().type
-    var company = Helpers.createTransaction().business
     return transactionType + " transaction at " + company + " using card ending with ***" + card + " for " + currency + " " + amount + " in account ***" + account
-  }
+  };
 
 };
 

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -172,7 +172,7 @@ describe('finance.js', function () {
             assert.ok(amount);
             assert.strictEqual(amount , '100.0', "the amount should be equal 100.0");
         });
-        
+
         //TODO: add support for more currency and decimal options
         it("should not include a currency symbol by default", function () {
 
@@ -395,10 +395,19 @@ describe('finance.js', function () {
     });
 
     describe("transactionDescription()", function() {
-			it("returns a random transaction description", function() {
-				var transactionDescription = faker.finance.transactionDescription();
+        beforeEach(function () {
+            sinon.spy(faker.helpers, 'createTransaction');
+        });
 
-				assert.ok(transactionDescription);
-			})
-    })
+        afterEach(function () {
+            faker.helpers.createTransaction.restore();
+        });
+
+        it("returns a random transaction description", function() {
+            var transactionDescription = faker.finance.transactionDescription();
+
+            assert.ok(transactionDescription);
+            assert.ok(faker.helpers.createTransaction.calledOnce);
+        });
+    });
 });


### PR DESCRIPTION
✅ Closes: #1108 

# ↪️ Pull Request

 * Remove multiple calls to `createTransaction` from within the `finance.transactionDescription` method and instead reference the required values from the returned transaction object.
 * Provide the unit test(s) for the code change.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs.

## 📝 Additional notes

After the change I ensured that:
 * all tests are passing, by running `npm run test`,
 * formating / code style is consistent.