### PR TITLE
Issue 1114 new datatype module

### DIFF
--- a/build/src/docs.md
+++ b/build/src/docs.md
@@ -99,12 +99,12 @@ If you want consistent results, you can set your own seed:
 ```js
 faker.seed(123);
 
-var firstRandom = faker.random.number();
+var firstRandom = faker.datatype.number();
 
 // Setting the seed again resets the sequence.
 faker.seed(123);
 
-var secondRandom = faker.random.number();
+var secondRandom = faker.datatype.number();
 
 console.log(firstRandom === secondRandom);
 ```

--- a/examples/node/generateMultiLevelMultiLocaleJSON.js
+++ b/examples/node/generateMultiLevelMultiLocaleJSON.js
@@ -5,7 +5,7 @@
 var faker = require('../../index');
 var fs = require('fs');
 // produce array with random number of empty elements 
-const arr = (maxNumberOfElements) => new Array(faker.random.number({min: 1, max: maxNumberOfElements})).fill()
+const arr = (maxNumberOfElements) => new Array(faker.datatype.number({min: 1, max: maxNumberOfElements})).fill()
 
 const locales = ["nl","es","de","fr","en_AU"]
 const company = 
@@ -18,7 +18,7 @@ const company =
                                                                  return { "name"     : faker.fake("{{name.firstName}} {{name.lastName}}")
                                                                         , "job"      : faker.name.jobTitle()
                                                                         , "hiredate" : faker.date.past(12).toISOString().split('T')[0]
-                                                                        , "salary"   : faker.random.number(700, 9000)
+                                                                        , "salary"   : faker.datatype.number(700, 9000)
                                                                         }
                                                                })
                                                }

--- a/lib/address.js
+++ b/lib/address.js
@@ -39,7 +39,7 @@ function Address (faker) {
   this.zipCodeByState = function (state) {
     var zipRange = faker.definitions.address.postcode_by_state[state];
     if (zipRange) {
-      return faker.random.number(zipRange);
+      return faker.datatype.number(zipRange);
     }
     return faker.address.zipCode();
   }
@@ -73,7 +73,7 @@ function Address (faker) {
     }
 
     if (typeof format !== "number") {
-      format = faker.random.number(formats.length - 1);
+      format = faker.datatype.number(formats.length - 1);
     }
 
     return f(formats[format]);
@@ -118,7 +118,7 @@ function Address (faker) {
           suffix = " " + suffix
       }
 
-      switch (faker.random.number(1)) {
+      switch (faker.datatype.number(1)) {
       case 0:
           result = faker.name.lastName() + suffix;
           break;
@@ -141,7 +141,7 @@ function Address (faker) {
   this.streetAddress = function (useFullAddress) {
       if (useFullAddress === undefined) { useFullAddress = false; }
       var address = "";
-      switch (faker.random.number(2)) {
+      switch (faker.datatype.number(2)) {
       case 0:
           address = Helpers.replaceSymbolWithNumber("#####") + " " + faker.address.streetName();
           break;
@@ -257,7 +257,7 @@ function Address (faker) {
       min       = min || -90
       precision = precision || 4
 
-      return faker.random.number({
+      return faker.datatype.number({
         max: max,
         min: min,
         precision: parseFloat((0.0).toPrecision(precision) + '1')
@@ -277,7 +277,7 @@ function Address (faker) {
       min       = min || -180
       precision = precision || 4
 
-      return faker.random.number({
+      return faker.datatype.number({
         max: max,
         min: min,
         precision: parseFloat((0.0).toPrecision(precision) + '1')

--- a/lib/commerce.js
+++ b/lib/commerce.js
@@ -55,7 +55,7 @@ var Commerce = function (faker) {
           return symbol + 0.00;
       }
 
-      var randValue = faker.random.number({ max: max, min: min });
+      var randValue = faker.datatype.number({ max: max, min: min });
 
       return symbol + (Math.round(randValue * Math.pow(10, dec)) / Math.pow(10, dec)).toFixed(dec);
   };

--- a/lib/company.js
+++ b/lib/company.js
@@ -32,7 +32,7 @@ var Company = function (faker) {
     ];
 
     if (typeof format !== "number") {
-      format = faker.random.number(formats.length - 1);
+      format = faker.datatype.number(formats.length - 1);
     }
 
     return f(formats[format]);

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -1,25 +1,10 @@
 var mersenne = require('../vendor/mersenne');
 
 /**
- * Method to reduce array of characters
- * @param arr existing array of characters
- * @param values array of characters which should be removed
- * @return {*} new array without banned characters
- */
-var arrayRemove = function (arr, values) {
-    values.forEach(function(value){
-        arr = arr.filter(function(ele){
-            return ele !== value;
-        });
-    });
-    return arr;
-};
-
-/**
  *
- * @namespace faker.dataType
+ * @namespace faker.datatype
  */
-function DataType (faker, seed) {
+function Datatype (faker, seed) {
     // Use a user provided seed if it is an array or number
     if (Array.isArray(seed) && seed.length) {
         mersenne.seed_array(seed);
@@ -31,7 +16,7 @@ function DataType (faker, seed) {
     /**
      * returns a single random number based on a max number or range
      *
-     * @method faker.random.number
+     * @method faker.datatype.number
      * @param {mixed} options {min, max, precision}
      */
     this.number = function (options) {
@@ -73,7 +58,7 @@ function DataType (faker, seed) {
     /**
      * returns a single random floating-point number based on a max number or range
      *
-     * @method faker.random.float
+     * @method faker.datatype.float
      * @param {mixed} options
      */
     this.float = function (options) {
@@ -90,58 +75,29 @@ function DataType (faker, seed) {
         if (typeof opts.precision === 'undefined') {
             opts.precision = 0.01;
         }
-        return faker.random.number(opts);
+        return faker.datatype.number(opts);
     };
 
     /**
-     * takes an array and returns a random element of the array
+     * Similar to description of Date by MDN,
+     * this method uses a random number of milliseconds since 1. Jan 1970 UTC to return a Date object
      *
-     * @method faker.random.arrayElement
-     * @param {array} array
+     * @method faker.datatype.date
      */
-    this.arrayElement = function (array) {
-        array = array || ["a", "b", "c"];
-        var r = faker.random.number({ max: array.length - 1 });
-        return array[r];
-    };
-
-    /**
-     * takes an array and returns a subset with random elements of the array
-     *
-     * @method faker.random.arrayElements
-     * @param {array} array
-     * @param {number} count number of elements to pick
-     */
-    this.arrayElements = function (array, count) {
-        array = array || ["a", "b", "c"];
-
-        if (typeof count !== 'number') {
-            count = faker.random.number({ min: 1, max: array.length });
-        } else if (count > array.length) {
-            count = array.length;
-        } else if (count < 0) {
-            count = 0;
-        }
-
-        var arrayCopy = array.slice();
-        var countToRemove = arrayCopy.length - count;
-        for (var i = 0; i < countToRemove; i++) {
-            var indexToRemove = faker.random.number({ max: arrayCopy.length - 1 });
-            arrayCopy.splice(indexToRemove, 1);
-        }
-
-        return arrayCopy;
+    this.date = function () {
+        var random = faker.datatype.number({ min: 0, max: 8600000000000000 });
+        return new Date(random);
     };
 
     /**
      * uuid
      *
-     * @method faker.random.uuid
+     * @method faker.datatype.uuid
      */
     this.uuid = function () {
         var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
         var replacePlaceholders = function (placeholder) {
-            var random = faker.random.number({ min: 0, max: 15 });
+            var random = faker.datatype.number({ min: 0, max: 15 });
             var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
             return value.toString(16);
         };
@@ -151,17 +107,17 @@ function DataType (faker, seed) {
     /**
      * boolean
      *
-     * @method faker.random.boolean
+     * @method faker.datatype.boolean
      */
     this.boolean = function () {
-        return !!faker.random.number(1)
+        return !!faker.datatype.number(1)
     };
 
 
     /**
      * hexaDecimal
      *
-     * @method faker.random.hexaDecimal
+     * @method faker.datatype.hexaDecimal
      * @param {number} count defaults to 1
      */
     this.hexaDecimal = function hexaDecimal(count) {
@@ -181,4 +137,4 @@ function DataType (faker, seed) {
 
 }
 
-module['exports'] = DataType;
+module['exports'] = Datatype;

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -80,11 +80,12 @@ function Datatype (faker, seed) {
 
     /**
      * method returns a Date object using a random number of milliseconds since 1. Jan 1970 UTC
+     * Caveat: seeding is not working
      *
      * @method faker.datatype.date
      * @param {mixed} options, pass min OR max as number of milliseconds since 1. Jan 1970 UTC
      */
-    this.date = function (options) {
+    this.datetime = function (options) {
         if (typeof options === "number") {
             options = {
                 max: options
@@ -220,8 +221,6 @@ function Datatype (faker, seed) {
         return returnArray;
 
     };
-
-
 
     return this;
 }

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -41,12 +41,12 @@ function Datatype (faker, seed) {
         }
 
         // Make the range inclusive of the max value
-        var max = options.max;
+        let max = options.max;
         if (max >= 0) {
             max += options.precision;
         }
 
-        var randomNumber = Math.floor(
+        let randomNumber = Math.floor(
             mersenne.rand(max / options.precision, options.min / options.precision));
         // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
         randomNumber = randomNumber / (1 / options.precision);
@@ -68,8 +68,8 @@ function Datatype (faker, seed) {
             };
         }
         options = options || {};
-        var opts = {};
-        for (var p in options) {
+        let opts = {};
+        for (let p in options) {
             opts[p] = options[p];
         }
         if (typeof opts.precision === 'undefined') {
@@ -83,6 +83,7 @@ function Datatype (faker, seed) {
      * this method uses a random number of milliseconds since 1. Jan 1970 UTC to return a Date object
      *
      * @method faker.datatype.date
+     * @param {mixed} options, pass min or max as number of milliseconds since 1. Jan 1970 UTC
      */
     this.date = function (options) {
         if (typeof options === "number") {
@@ -91,7 +92,7 @@ function Datatype (faker, seed) {
             };
         }
 
-        var minMax = 8640000000000000;
+        const minMax = 8640000000000000;
 
         options = options || {};
 
@@ -103,8 +104,37 @@ function Datatype (faker, seed) {
             options.max = new Date().setFullYear(2100,1,1);
         }
 
-        var random = faker.datatype.number(options);
+        const random = faker.datatype.number(options);
         return new Date(random);
+    };
+
+    /**
+     * Returns a string, containing UTF-16 chars between 33 and 125 ('!' to '}')
+     *
+     *
+     * @method faker.datatype.string
+     * @param { number } strLength: length of generated string, default = 10, max length = 2^20
+     */
+    this.string = function (strLength) {
+        if(strLength === undefined ){
+           strLength = 10;
+        }
+
+        const maxLength = Math.pow(2, 20);
+        if(strLength >= (maxLength)){
+            strLength = maxLength
+        }
+
+        const charCodeOption = {
+            min: 33,
+            max: 125
+        }
+        let returnString = '';
+
+        for(let i = 0; i < strLength; i++){
+            returnString += String.fromCharCode(faker.datatype.number(charCodeOption));
+        }
+        return returnString;
     };
 
     /**
@@ -113,10 +143,10 @@ function Datatype (faker, seed) {
      * @method faker.datatype.uuid
      */
     this.uuid = function () {
-        var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
-        var replacePlaceholders = function (placeholder) {
-            var random = faker.datatype.number({ min: 0, max: 15 });
-            var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
+        const RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+        const replacePlaceholders = function (placeholder) {
+            const random = faker.datatype.number({ min: 0, max: 15 });
+            const value = placeholder == 'x' ? random : (random &0x3 | 0x8);
             return value.toString(16);
         };
         return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
@@ -143,16 +173,33 @@ function Datatype (faker, seed) {
             count = 1;
         }
 
-        var wholeString = "";
-        for(var i = 0; i < count; i++) {
+        let wholeString = "";
+        for(let i = 0; i < count; i++) {
             wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
         }
 
         return "0x"+wholeString;
     };
 
-    return this;
+    /**
+     * returns
+     *
+     * @method faker.datatype.json
+     */
+    this.json = function json() {
 
+        const properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop']
+
+        let returnObject = {};
+        properties.map((prop, i) => {
+            returnObject[prop] = i%faker.datatype.number({min:1, max:3}) === 0 ?
+                faker.datatype.string() : faker.datatype.number();
+        })
+
+        return JSON.stringify(returnObject);
+    };
+
+    return this;
 }
 
 module['exports'] = Datatype;

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -82,7 +82,7 @@ function Datatype (faker, seed) {
      * method returns a Date object using a random number of milliseconds since 1. Jan 1970 UTC
      * Caveat: seeding is not working
      *
-     * @method faker.datatype.date
+     * @method faker.datatype.datetime
      * @param {mixed} options, pass min OR max as number of milliseconds since 1. Jan 1970 UTC
      */
     this.datetime = function (options) {

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -84,8 +84,26 @@ function Datatype (faker, seed) {
      *
      * @method faker.datatype.date
      */
-    this.date = function () {
-        var random = faker.datatype.number({ min: 0, max: 8600000000000000 });
+    this.date = function (options) {
+        if (typeof options === "number") {
+            options = {
+                max: options
+            };
+        }
+
+        var minMax = 8640000000000000;
+
+        options = options || {};
+
+        if (typeof options.min === "undefined" || options.min < minMax*-1) {
+            options.min = new Date().setFullYear(1990, 1, 1);
+        }
+
+        if (typeof options.max === "undefined" || options.max > minMax) {
+            options.max = new Date().setFullYear(2100,1,1);
+        }
+
+        var random = faker.datatype.number(options);
         return new Date(random);
     };
 

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -41,12 +41,12 @@ function Datatype (faker, seed) {
         }
 
         // Make the range inclusive of the max value
-        let max = options.max;
+        var max = options.max;
         if (max >= 0) {
             max += options.precision;
         }
 
-        let randomNumber = Math.floor(
+        var randomNumber = Math.floor(
             mersenne.rand(max / options.precision, options.min / options.precision));
         // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
         randomNumber = randomNumber / (1 / options.precision);
@@ -68,8 +68,8 @@ function Datatype (faker, seed) {
             };
         }
         options = options || {};
-        let opts = {};
-        for (let p in options) {
+        var opts = {};
+        for (var p in options) {
             opts[p] = options[p];
         }
         if (typeof opts.precision === 'undefined') {
@@ -79,11 +79,10 @@ function Datatype (faker, seed) {
     };
 
     /**
-     * Similar to description of Date by MDN,
-     * this method uses a random number of milliseconds since 1. Jan 1970 UTC to return a Date object
+     * method returns a Date object using a random number of milliseconds since 1. Jan 1970 UTC
      *
      * @method faker.datatype.date
-     * @param {mixed} options, pass min or max as number of milliseconds since 1. Jan 1970 UTC
+     * @param {mixed} options, pass min OR max as number of milliseconds since 1. Jan 1970 UTC
      */
     this.date = function (options) {
         if (typeof options === "number") {
@@ -92,7 +91,7 @@ function Datatype (faker, seed) {
             };
         }
 
-        const minMax = 8640000000000000;
+        var minMax = 8640000000000000;
 
         options = options || {};
 
@@ -104,7 +103,7 @@ function Datatype (faker, seed) {
             options.max = new Date().setFullYear(2100,1,1);
         }
 
-        const random = faker.datatype.number(options);
+        var random = faker.datatype.number(options);
         return new Date(random);
     };
 
@@ -113,25 +112,26 @@ function Datatype (faker, seed) {
      *
      *
      * @method faker.datatype.string
-     * @param { number } strLength: length of generated string, default = 10, max length = 2^20
+     * @param { number } length: length of generated string, default = 10, max length = 2^20
      */
-    this.string = function (strLength) {
-        if(strLength === undefined ){
-           strLength = 10;
+    this.string = function (length) {
+        if(length === undefined ){
+           length = 10;
         }
 
-        const maxLength = Math.pow(2, 20);
-        if(strLength >= (maxLength)){
-            strLength = maxLength
+        var maxLength = Math.pow(2, 20);
+        if(length >= (maxLength)){
+            length = maxLength;
         }
 
-        const charCodeOption = {
+        var charCodeOption = {
             min: 33,
             max: 125
-        }
-        let returnString = '';
+        };
 
-        for(let i = 0; i < strLength; i++){
+        var returnString = '';
+
+        for(var i = 0; i < length; i++){
             returnString += String.fromCharCode(faker.datatype.number(charCodeOption));
         }
         return returnString;
@@ -143,10 +143,10 @@ function Datatype (faker, seed) {
      * @method faker.datatype.uuid
      */
     this.uuid = function () {
-        const RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
-        const replacePlaceholders = function (placeholder) {
-            const random = faker.datatype.number({ min: 0, max: 15 });
-            const value = placeholder == 'x' ? random : (random &0x3 | 0x8);
+        var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+        var replacePlaceholders = function (placeholder) {
+            var random = faker.datatype.number({ min: 0, max: 15 });
+            var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
             return value.toString(16);
         };
         return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
@@ -158,7 +158,7 @@ function Datatype (faker, seed) {
      * @method faker.datatype.boolean
      */
     this.boolean = function () {
-        return !!faker.datatype.number(1)
+        return !!faker.datatype.number(1);
     };
 
 
@@ -173,8 +173,8 @@ function Datatype (faker, seed) {
             count = 1;
         }
 
-        let wholeString = "";
-        for(let i = 0; i < count; i++) {
+        var wholeString = "";
+        for(var i = 0; i < count; i++) {
             wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
         }
 
@@ -182,22 +182,46 @@ function Datatype (faker, seed) {
     };
 
     /**
-     * returns
+     * returns json object with 7 pre-defined properties
      *
      * @method faker.datatype.json
      */
     this.json = function json() {
 
-        const properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop']
+        var properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop'];
 
-        let returnObject = {};
-        properties.map((prop, i) => {
-            returnObject[prop] = i%faker.datatype.number({min:1, max:3}) === 0 ?
+        var returnObject = {};
+        properties.forEach(function(prop){
+            returnObject[prop] = faker.datatype.boolean() ?
                 faker.datatype.string() : faker.datatype.number();
-        })
+        });
 
         return JSON.stringify(returnObject);
     };
+
+    /**
+     * returns an array with values generated by faker.datatype.number and faker.datatype.string
+     *
+     * @method faker.datatype.custarray
+     * @param { number } length of the returned array
+     */
+
+    this.array = function array(length) {
+
+
+        if(length === undefined){
+            length = 10;
+        }
+        var returnArray = new Array(length);
+        for(var i = 0; i < length; i++){
+            returnArray[i] = faker.datatype.boolean() ?
+                faker.datatype.string() : faker.datatype.number();
+        }
+        return returnArray;
+
+    };
+
+
 
     return this;
 }

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -1,0 +1,184 @@
+var mersenne = require('../vendor/mersenne');
+
+/**
+ * Method to reduce array of characters
+ * @param arr existing array of characters
+ * @param values array of characters which should be removed
+ * @return {*} new array without banned characters
+ */
+var arrayRemove = function (arr, values) {
+    values.forEach(function(value){
+        arr = arr.filter(function(ele){
+            return ele !== value;
+        });
+    });
+    return arr;
+};
+
+/**
+ *
+ * @namespace faker.dataType
+ */
+function DataType (faker, seed) {
+    // Use a user provided seed if it is an array or number
+    if (Array.isArray(seed) && seed.length) {
+        mersenne.seed_array(seed);
+    }
+    else if(!isNaN(seed)) {
+        mersenne.seed(seed);
+    }
+
+    /**
+     * returns a single random number based on a max number or range
+     *
+     * @method faker.random.number
+     * @param {mixed} options {min, max, precision}
+     */
+    this.number = function (options) {
+
+        if (typeof options === "number") {
+            options = {
+                max: options
+            };
+        }
+
+        options = options || {};
+
+        if (typeof options.min === "undefined") {
+            options.min = 0;
+        }
+
+        if (typeof options.max === "undefined") {
+            options.max = 99999;
+        }
+        if (typeof options.precision === "undefined") {
+            options.precision = 1;
+        }
+
+        // Make the range inclusive of the max value
+        var max = options.max;
+        if (max >= 0) {
+            max += options.precision;
+        }
+
+        var randomNumber = Math.floor(
+            mersenne.rand(max / options.precision, options.min / options.precision));
+        // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
+        randomNumber = randomNumber / (1 / options.precision);
+
+        return randomNumber;
+
+    };
+
+    /**
+     * returns a single random floating-point number based on a max number or range
+     *
+     * @method faker.random.float
+     * @param {mixed} options
+     */
+    this.float = function (options) {
+        if (typeof options === "number") {
+            options = {
+                precision: options
+            };
+        }
+        options = options || {};
+        var opts = {};
+        for (var p in options) {
+            opts[p] = options[p];
+        }
+        if (typeof opts.precision === 'undefined') {
+            opts.precision = 0.01;
+        }
+        return faker.random.number(opts);
+    };
+
+    /**
+     * takes an array and returns a random element of the array
+     *
+     * @method faker.random.arrayElement
+     * @param {array} array
+     */
+    this.arrayElement = function (array) {
+        array = array || ["a", "b", "c"];
+        var r = faker.random.number({ max: array.length - 1 });
+        return array[r];
+    };
+
+    /**
+     * takes an array and returns a subset with random elements of the array
+     *
+     * @method faker.random.arrayElements
+     * @param {array} array
+     * @param {number} count number of elements to pick
+     */
+    this.arrayElements = function (array, count) {
+        array = array || ["a", "b", "c"];
+
+        if (typeof count !== 'number') {
+            count = faker.random.number({ min: 1, max: array.length });
+        } else if (count > array.length) {
+            count = array.length;
+        } else if (count < 0) {
+            count = 0;
+        }
+
+        var arrayCopy = array.slice();
+        var countToRemove = arrayCopy.length - count;
+        for (var i = 0; i < countToRemove; i++) {
+            var indexToRemove = faker.random.number({ max: arrayCopy.length - 1 });
+            arrayCopy.splice(indexToRemove, 1);
+        }
+
+        return arrayCopy;
+    };
+
+    /**
+     * uuid
+     *
+     * @method faker.random.uuid
+     */
+    this.uuid = function () {
+        var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+        var replacePlaceholders = function (placeholder) {
+            var random = faker.random.number({ min: 0, max: 15 });
+            var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
+            return value.toString(16);
+        };
+        return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
+    };
+
+    /**
+     * boolean
+     *
+     * @method faker.random.boolean
+     */
+    this.boolean = function () {
+        return !!faker.random.number(1)
+    };
+
+
+    /**
+     * hexaDecimal
+     *
+     * @method faker.random.hexaDecimal
+     * @param {number} count defaults to 1
+     */
+    this.hexaDecimal = function hexaDecimal(count) {
+        if (typeof count === "undefined") {
+            count = 1;
+        }
+
+        var wholeString = "";
+        for(var i = 0; i < count; i++) {
+            wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
+        }
+
+        return "0x"+wholeString;
+    };
+
+    return this;
+
+}
+
+module['exports'] = DataType;

--- a/lib/date.js
+++ b/lib/date.js
@@ -23,7 +23,7 @@ var _Date = function (faker) {
       };
 
       var past = date.getTime();
-      past -= faker.random.number(range); // some time from now to N years ago, in milliseconds
+      past -= faker.datatype.number(range); // some time from now to N years ago, in milliseconds
       date.setTime(past);
 
       return date;
@@ -48,7 +48,7 @@ var _Date = function (faker) {
       };
 
       var future = date.getTime();
-      future += faker.random.number(range); // some time from now to N years later, in milliseconds
+      future += faker.datatype.number(range); // some time from now to N years later, in milliseconds
       date.setTime(future);
 
       return date;
@@ -63,7 +63,7 @@ var _Date = function (faker) {
    */
   self.between = function (from, to) {
       var fromMilli = Date.parse(from);
-      var dateOffset = faker.random.number(Date.parse(to) - fromMilli);
+      var dateOffset = faker.datatype.number(Date.parse(to) - fromMilli);
 
       var newDate = new Date(fromMilli + dateOffset);
 
@@ -111,7 +111,7 @@ var _Date = function (faker) {
       };
 
       var future = date.getTime();
-      future -= faker.random.number(range); // some time from now to N days ago, in milliseconds
+      future -= faker.datatype.number(range); // some time from now to N days ago, in milliseconds
       date.setTime(future);
 
       return date;
@@ -136,7 +136,7 @@ var _Date = function (faker) {
       };
 
       var future = date.getTime();
-      future += faker.random.number(range); // some time from now to N days later, in milliseconds
+      future += faker.datatype.number(range); // some time from now to N days later, in milliseconds
       date.setTime(future);
 
       return date;

--- a/lib/finance.js
+++ b/lib/finance.js
@@ -109,7 +109,7 @@ var Finance = function (faker) {
       max = max || 1000;
       dec = dec === undefined ? 2 : dec;
       symbol = symbol || '';
-      const randValue = faker.random.number({ max: max, min: min, precision: Math.pow(10, -dec) });
+      const randValue = faker.datatype.number({ max: max, min: min, precision: Math.pow(10, -dec) });
 
       let formattedString;
       if(autoFormat) {
@@ -169,7 +169,7 @@ var Finance = function (faker) {
    * @method  faker.finance.bitcoinAddress
    */
   self.bitcoinAddress = function () {
-    var addressLength = faker.random.number({ min: 25, max: 34 });
+    var addressLength = faker.datatype.number({ min: 25, max: 34 });
 
     var address = faker.random.arrayElement(['1', '3']);
 
@@ -185,7 +185,7 @@ var Finance = function (faker) {
  * @method  faker.finance.litecoinAddress
  */
 self.litecoinAddress = function () {
-  var addressLength = faker.random.number({ min: 26, max: 33 });
+  var addressLength = faker.datatype.number({ min: 26, max: 33 });
 
   var address = faker.random.arrayElement(['L', 'M', '3']);
 
@@ -236,7 +236,7 @@ self.litecoinAddress = function () {
   self.creditCardCVV = function() {
     var cvv = "";
     for (var i = 0; i < 3; i++) {
-      cvv += faker.random.number({max:9}).toString();
+      cvv += faker.datatype.number({max:9}).toString();
     }
     return cvv;
   };
@@ -247,8 +247,7 @@ self.litecoinAddress = function () {
    * @method  faker.finance.ethereumAddress
    */
   self.ethereumAddress = function () {
-    var address = faker.random.hexaDecimal(40).toLowerCase();
-
+    var address = faker.datatype.hexaDecimal(40).toLowerCase();
     return address;
   };
 
@@ -284,14 +283,14 @@ self.litecoinAddress = function () {
               if (bban.type == "a") {
                   s += faker.random.arrayElement(ibanLib.alpha);
               } else if (bban.type == "c") {
-                  if (faker.random.number(100) < 80) {
-                      s += faker.random.number(9);
+                  if (faker.datatype.number(100) < 80) {
+                      s += faker.datatype.number(9);
                   } else {
                       s += faker.random.arrayElement(ibanLib.alpha);
                   }
               } else {
-                  if (c >= 3 && faker.random.number(100) < 30) {
-                      if (faker.random.boolean()) {
+                  if (c >= 3 && faker.datatype.number(100) < 30) {
+                      if (faker.datatype.boolean()) {
                           s += faker.random.arrayElement(ibanLib.pattern100);
                           c -= 2;
                       } else {
@@ -299,7 +298,7 @@ self.litecoinAddress = function () {
                           c--;
                       }
                   } else {
-                      s += faker.random.number(9);
+                      s += faker.datatype.number(9);
                   }
               }
               c--;
@@ -321,7 +320,7 @@ self.litecoinAddress = function () {
    */
   self.bic = function () {
       var vowels = ["A", "E", "I", "O", "U"];
-      var prob = faker.random.number(100);
+      var prob = faker.datatype.number(100);
       return Helpers.replaceSymbols("???") +
           faker.random.arrayElement(vowels) +
           faker.random.arrayElement(ibanLib.iso3166) +

--- a/lib/git.js
+++ b/lib/git.js
@@ -30,7 +30,7 @@ var Git = function(faker) {
 
     var entry = 'commit {{git.commitSha}}\r\n';
 
-    if (options.merge || (faker.random.number({ min: 0, max: 4 }) === 0)) {
+    if (options.merge || (faker.datatype.number({ min: 0, max: 4 }) === 0)) {
       entry += 'Merge: {{git.shortSha}} {{git.shortSha}}\r\n';
     }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -45,9 +45,9 @@ var Helpers = function (faker) {
       var str = '';
       for (var i = 0; i < string.length; i++) {
           if (string.charAt(i) == symbol) {
-              str += faker.random.number(9);
+              str += faker.datatype.number(9);
           } else if (string.charAt(i) == "!"){
-              str += faker.random.number({min: 2, max: 9});
+              str += faker.datatype.number({min: 2, max: 9});
           } else {
               str += string.charAt(i);
           }
@@ -69,11 +69,11 @@ var Helpers = function (faker) {
 
       for (var i = 0; i < string.length; i++) {
           if (string.charAt(i) == "#") {
-              str += faker.random.number(9);
+              str += faker.datatype.number(9);
           } else if (string.charAt(i) == "?") {
               str += faker.random.arrayElement(alpha);
           } else if (string.charAt(i) == "*") {
-            str += faker.random.boolean() ? faker.random.arrayElement(alpha) : faker.random.number(9);
+            str += faker.datatype.boolean() ? faker.random.arrayElement(alpha) : faker.datatype.number(9);
           } else {
               str += string.charAt(i);
           }
@@ -161,7 +161,7 @@ var Helpers = function (faker) {
          max = min;
          min = tmp;
        }
-       repetitions = faker.random.number({min:min,max:max});
+       repetitions = faker.datatype.number({min:min,max:max});
        string = string.slice(0,token.index) + faker.helpers.repeatString(token[1], repetitions) + string.slice(token.index+token[0].length);
        token = string.match(RANGE_REP_REG);
      }
@@ -186,7 +186,7 @@ var Helpers = function (faker) {
          min = tmp;
        }
         string = string.slice(0,token.index) +
-          faker.random.number({min:min, max:max}).toString() +
+          faker.datatype.number({min:min, max:max}).toString() +
           string.slice(token.index+token[0].length);
         token = string.match(RANGE_REG);
      }
@@ -207,7 +207,7 @@ var Helpers = function (faker) {
       }
       o = o || ["a", "b", "c"];
       for (var x, j, i = o.length - 1; i > 0; --i) {
-        j = faker.random.number(i);
+        j = faker.datatype.number(i);
         x = o[i];
         o[i] = o[j];
         o[j] = x;

--- a/lib/image.js
+++ b/lib/image.js
@@ -55,7 +55,7 @@ var Image = function (faker) {
       }
 
       if (randomize) {
-        url += '?' + faker.random.number()
+        url += '?' + faker.datatype.number()
       }
 
       return url;

--- a/lib/image_providers/lorempixel.js
+++ b/lib/image_providers/lorempixel.js
@@ -46,7 +46,7 @@ var Lorempixel = function (faker) {
       }
 
       if (randomize) {
-        url += '?' + faker.random.number()
+        url += '?' + faker.datatype.number()
       }
 
       return url;

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,8 +104,8 @@ function Faker (opts) {
   var Music = require('./music');
   self.music = new Music(self);
 
-  var DataType = require('./datatype');
-  self.datatype = new DataType(self);
+  var Datatype = require('./datatype');
+  self.datatype = new Datatype(self);
 
   var _definitions = {
     "name": ["first_name", "last_name", "prefix", "suffix", "binary_gender", "gender", "title", "male_prefix", "female_prefix", "male_first_name", "female_first_name", "male_middle_name", "female_middle_name", "male_last_name", "female_last_name"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,9 @@ function Faker (opts) {
   var Music = require('./music');
   self.music = new Music(self);
 
+  var DataType = require('./datatype');
+  self.datatype = new DataType(self);
+
   var _definitions = {
     "name": ["first_name", "last_name", "prefix", "suffix", "binary_gender", "gender", "title", "male_prefix", "female_prefix", "male_first_name", "female_first_name", "male_middle_name", "female_middle_name", "male_last_name", "female_last_name"],
     "address": ["city_name", "city_prefix", "city_suffix", "street_suffix", "county", "country", "country_code", "country_code_alpha_3", "state", "state_abbr", "street_prefix", "postcode", "postcode_by_state", "direction", "direction_abbr", "time_zone"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,9 @@ Faker.prototype.setLocale = function (locale) {
 
 Faker.prototype.seed = function(value) {
   var Random = require('./random');
+  var Datatype = require('./datatype');
   this.seedValue = value;
   this.random = new Random(this, this.seedValue);
+  this.datatype = new Datatype(this, this.seedValue);
 }
 module['exports'] = Faker;

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -77,15 +77,15 @@ var Internet = function (faker) {
       var result;
       firstName = firstName || faker.name.firstName();
       lastName = lastName || faker.name.lastName();
-      switch (faker.random.number(2)) {
+      switch (faker.datatype.number(2)) {
       case 0:
-          result = firstName + faker.random.number(99);
+          result = firstName + faker.datatype.number(99);
           break;
       case 1:
           result = firstName + faker.random.arrayElement([".", "_"]) + lastName;
           break;
       case 2:
-          result = firstName + faker.random.arrayElement([".", "_"]) + lastName + faker.random.number(99);
+          result = firstName + faker.random.arrayElement([".", "_"]) + lastName + faker.datatype.number(99);
           break;
       }
       result = result.toString().replace(/'/g, "");
@@ -212,7 +212,7 @@ var Internet = function (faker) {
    */
   self.ip = function () {
       var randNum = function () {
-          return (faker.random.number(255)).toFixed(0);
+          return (faker.datatype.number(255)).toFixed(0);
       };
 
       var result = [];
@@ -260,7 +260,7 @@ var Internet = function (faker) {
    * @method faker.internet.port
    */
   self.port = function() {
-    return faker.random.number({ min: 0, max: 65535 });
+    return faker.datatype.number({ min: 0, max: 65535 });
   };
 
   self.port.schema = {
@@ -295,9 +295,9 @@ var Internet = function (faker) {
       baseGreen255 = baseGreen255 || 0;
       baseBlue255 = baseBlue255 || 0;
       // based on awesome response : http://stackoverflow.com/questions/43044/algorithm-to-randomly-generate-an-aesthetically-pleasing-color-palette
-      var red = Math.floor((faker.random.number(256) + baseRed255) / 2);
-      var green = Math.floor((faker.random.number(256) + baseGreen255) / 2);
-      var blue = Math.floor((faker.random.number(256) + baseBlue255) / 2);
+      var red = Math.floor((faker.datatype.number(256) + baseRed255) / 2);
+      var green = Math.floor((faker.datatype.number(256) + baseGreen255) / 2);
+      var blue = Math.floor((faker.datatype.number(256) + baseBlue255) / 2);
       var redStr = red.toString(16);
       var greenStr = green.toString(16);
       var blueStr = blue.toString(16);
@@ -348,7 +348,7 @@ var Internet = function (faker) {
       } 
 
       for (i=0; i < 12; i++) {
-          mac+= faker.random.number(15).toString(16);
+          mac+= faker.datatype.number(15).toString(16);
           if (i%2==1 && i != 11) {
               mac+=validSep;
           }
@@ -408,7 +408,7 @@ var Internet = function (faker) {
            pattern = consonant;
          }
        }
-       n = faker.random.number(94) + 33;
+       n = faker.datatype.number(94) + 33;
        char = String.fromCharCode(n);
        if (memorable) {
          char = char.toLowerCase();

--- a/lib/locales/en/animal/dog.js
+++ b/lib/locales/en/animal/dog.js
@@ -100,7 +100,7 @@ module["exports"] = [
   'Burgos Pointer',
   "Cairn Terrier",
   "Campeiro Bulldog",
-  "Canaan Dog",,
+  "Canaan Dog",
   "Canadian Eskimo Dog",
   "Cane Corso",
   "Cane di Oropa",

--- a/lib/lorem.js
+++ b/lib/lorem.js
@@ -47,7 +47,7 @@ var Lorem = function (faker) {
    * @param {number} range
    */
   self.sentence = function (wordCount, range) {
-      if (typeof wordCount == 'undefined') { wordCount = faker.random.number({ min: 3, max: 10 }); }
+      if (typeof wordCount == 'undefined') { wordCount = faker.datatype.number({ min: 3, max: 10 }); }
       // if (typeof range == 'undefined') { range = 7; }
 
       // strange issue with the node_min_test failing for captialize, please fix and add faker.lorem.back
@@ -76,7 +76,7 @@ var Lorem = function (faker) {
    * @param {string} separator defaults to `' '`
    */
   self.sentences = function (sentenceCount, separator) {
-      if (typeof sentenceCount === 'undefined') { sentenceCount = faker.random.number({ min: 2, max: 6 });}
+      if (typeof sentenceCount === 'undefined') { sentenceCount = faker.datatype.number({ min: 2, max: 6 });}
       if (typeof separator == 'undefined') { separator = " "; }
       var sentences = [];
       for (sentenceCount; sentenceCount > 0; sentenceCount--) {
@@ -93,7 +93,7 @@ var Lorem = function (faker) {
    */
   self.paragraph = function (sentenceCount) {
       if (typeof sentenceCount == 'undefined') { sentenceCount = 3; }
-      return faker.lorem.sentences(sentenceCount + faker.random.number(3));
+      return faker.lorem.sentences(sentenceCount + faker.datatype.number(3));
   };
 
   /**
@@ -134,7 +134,7 @@ var Lorem = function (faker) {
    * @param {number} lineCount defaults to a random number between 1 and 5
    */
   self.lines = function lines (lineCount) {
-    if (typeof lineCount === 'undefined') { lineCount = faker.random.number({ min: 1, max: 5 });}
+    if (typeof lineCount === 'undefined') { lineCount = faker.datatype.number({ min: 1, max: 5 });}
     return faker.lorem.sentences(lineCount, '\n')
   };
 

--- a/lib/name.js
+++ b/lib/name.js
@@ -27,7 +27,7 @@ function Name (faker) {
 
       if (typeof gender !== 'number') {
         if(typeof faker.definitions.name.first_name === "undefined") {
-          gender = faker.random.number(1);
+          gender = faker.datatype.number(1);
         }
         else {
           //Fall back to non-gendered names if they exist and gender wasn't specified
@@ -55,7 +55,7 @@ function Name (faker) {
       // some locale datasets ( like ru ) have last_name split by gender. i have no idea how last names can have genders, but also i do not speak russian
       // see above comment of firstName method
       if (typeof gender !== 'number') {
-        gender = faker.random.number(1);
+        gender = faker.datatype.number(1);
       }
       if (gender === 0) {
         return faker.random.arrayElement(faker.locales[faker.locale].name.male_last_name);
@@ -76,7 +76,7 @@ function Name (faker) {
   this.middleName = function (gender) {
     if (typeof faker.definitions.name.male_middle_name !== "undefined" && typeof faker.definitions.name.female_middle_name !== "undefined") {
       if (typeof gender !== 'number') {
-        gender = faker.random.number(1);
+        gender = faker.datatype.number(1);
       }
       if (gender === 0) {
         return faker.random.arrayElement(faker.locales[faker.locale].name.male_middle_name);
@@ -97,12 +97,12 @@ function Name (faker) {
    * @memberof faker.name
    */
   this.findName = function (firstName, lastName, gender) {
-      var r = faker.random.number(8);
+      var r = faker.datatype.number(8);
       var prefix, suffix;
       // in particular locales first and last names split by gender,
       // thus we keep consistency by passing 0 as male and 1 as female
       if (typeof gender !== 'number') {
-        gender = faker.random.number(1);
+        gender = faker.datatype.number(1);
       }
       firstName = firstName || faker.name.firstName(gender);
       lastName = lastName || faker.name.lastName(gender);
@@ -158,7 +158,7 @@ function Name (faker) {
   this.prefix = function (gender) {
     if (typeof faker.definitions.name.male_prefix !== "undefined" && typeof faker.definitions.name.female_prefix !== "undefined") {
       if (typeof gender !== 'number') {
-        gender = faker.random.number(1);
+        gender = faker.datatype.number(1);
       }
       if (gender === 0) {
         return faker.random.arrayElement(faker.locales[faker.locale].name.male_prefix);

--- a/lib/random.js
+++ b/lib/random.js
@@ -333,16 +333,8 @@ function Random (faker, seed) {
    * @param {number} count defaults to 1
    */
   this.hexaDecimal = function hexaDecimal(count) {
-    if (typeof count === "undefined") {
-      count = 1;
-    }
-
-    var wholeString = "";
-    for(var i = 0; i < count; i++) {
-      wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
-    }
-
-    return "0x"+wholeString;
+    console.log("DeprecationWarning: Method is now located in faker.datatype.hexaDecimal");
+    return faker.datatype.hexaDecimal(count);
   };
 
   return this;

--- a/lib/random.js
+++ b/lib/random.js
@@ -29,68 +29,27 @@ function Random (faker, seed) {
   }
 
   /**
+   * @Deprecated
    * returns a single random number based on a max number or range
    *
    * @method faker.random.number
    * @param {mixed} options {min, max, precision}
    */
   this.number = function (options) {
-
-    if (typeof options === "number") {
-      options = {
-        max: options
-      };
-    }
-
-    options = options || {};
-
-    if (typeof options.min === "undefined") {
-      options.min = 0;
-    }
-
-    if (typeof options.max === "undefined") {
-      options.max = 99999;
-    }
-    if (typeof options.precision === "undefined") {
-      options.precision = 1;
-    }
-
-    // Make the range inclusive of the max value
-    var max = options.max;
-    if (max >= 0) {
-      max += options.precision;
-    }
-
-    var randomNumber = Math.floor(
-      mersenne.rand(max / options.precision, options.min / options.precision));
-    // Workaround problem in Float point arithmetics for e.g. 6681493 / 0.01
-    randomNumber = randomNumber / (1 / options.precision);
-
-    return randomNumber;
-
+      console.log("DeprecationWarning: Method is now located in faker.datatype.number");
+      return faker.datatype.number(options);
   };
 
   /**
+   * @Deprecated
    * returns a single random floating-point number based on a max number or range
    *
    * @method faker.random.float
    * @param {mixed} options
    */
   this.float = function (options) {
-      if (typeof options === "number") {
-        options = {
-          precision: options
-        };
-      }
-      options = options || {};
-      var opts = {};
-      for (var p in options) {
-        opts[p] = options[p];
-      }
-      if (typeof opts.precision === 'undefined') {
-        opts.precision = 0.01;
-      }
-      return faker.random.number(opts);
+      console.log("DeprecationWarning: Method is now located in faker.datatype.float");
+      return faker.datatype.float(options);
   };
 
   /**
@@ -101,7 +60,7 @@ function Random (faker, seed) {
    */
   this.arrayElement = function (array) {
       array = array || ["a", "b", "c"];
-      var r = faker.random.number({ max: array.length - 1 });
+      var r = faker.datatype.number({ max: array.length - 1 });
       return array[r];
   };
 
@@ -116,7 +75,7 @@ function Random (faker, seed) {
       array = array || ["a", "b", "c"];
 
       if (typeof count !== 'number') {
-        count = faker.random.number({ min: 1, max: array.length });
+        count = faker.datatype.number({ min: 1, max: array.length });
       } else if (count > array.length) {
         count = array.length;
       } else if (count < 0) {
@@ -126,7 +85,7 @@ function Random (faker, seed) {
       var arrayCopy = array.slice();
       var countToRemove = arrayCopy.length - count;
       for (var i = 0; i < countToRemove; i++) {
-        var indexToRemove = faker.random.number({ max: arrayCopy.length - 1 });
+        var indexToRemove = faker.datatype.number({ max: arrayCopy.length - 1 });
         arrayCopy.splice(indexToRemove, 1);
       }
 
@@ -149,18 +108,14 @@ function Random (faker, seed) {
   };
 
   /**
+   * @Deprecated
    * uuid
    *
    * @method faker.random.uuid
    */
   this.uuid = function () {
-      var RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
-      var replacePlaceholders = function (placeholder) {
-          var random = faker.random.number({ min: 0, max: 15 });
-          var value = placeholder == 'x' ? random : (random &0x3 | 0x8);
-          return value.toString(16);
-      };
-      return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
+      console.log("DeprecationWarning: Method is now located in faker.datatype.uuid");
+      return faker.datatype.uuid();
   };
 
   /**
@@ -169,7 +124,8 @@ function Random (faker, seed) {
    * @method faker.random.boolean
    */
   this.boolean = function () {
-      return !!faker.random.number(1)
+      console.log("DeprecationWarning: Method is now located in faker.datatype.boolean");
+      return faker.datatype.boolean();
   };
 
   // TODO: have ability to return specific type of word? As in: noun, adjective, verb, etc
@@ -229,7 +185,7 @@ function Random (faker, seed) {
   this.words = function randomWords (count) {
     var words = [];
     if (typeof count === "undefined") {
-      count = faker.random.number({min:1, max: 3});
+      count = faker.datatype.number({min:1, max: 3});
     }
     for (var i = 0; i<count; i++) {
       words.push(faker.random.word());
@@ -327,6 +283,7 @@ function Random (faker, seed) {
   };
 
   /**
+   * @Deprecated
    * hexaDecimal
    *
    * @method faker.random.hexaDecimal

--- a/lib/system.js
+++ b/lib/system.js
@@ -151,9 +151,9 @@ function System (faker) {
    * @method faker.system.semver
    */
   this.semver = function () {
-      return [faker.random.number(9),
-              faker.random.number(9),
-              faker.random.number(9)].join('.');
+      return [faker.datatype.number(9),
+              faker.datatype.number(9),
+              faker.datatype.number(9)].join('.');
   }
 
 }

--- a/lib/vehicle.js
+++ b/lib/vehicle.js
@@ -88,7 +88,7 @@ var Vehicle = function (faker) {
       faker.random.alphaNumeric(10, {bannedChars:bannedChars}) +
       faker.random.alpha({ count: 1, upcase: true ,bannedChars:bannedChars}) +
       faker.random.alphaNumeric(1, {bannedChars:bannedChars}) +
-      faker.random.number({ min: 10000, max: 100000}) // return five digit #
+      faker.datatype.number({ min: 10000, max: 100000}) // return five digit #
     ).toUpperCase();
   };
 
@@ -119,8 +119,8 @@ var Vehicle = function (faker) {
     self.vrm = function () {
         return (
             faker.random.alpha({ count: 2, upcase: true }) +
-            faker.random.number({ min: 0, max: 9 }) +
-            faker.random.number({ min: 0, max: 9 }) +
+            faker.datatype.number({ min: 0, max: 9 }) +
+            faker.datatype.number({ min: 0, max: 9 }) +
             faker.random.alpha({ count: 3, upcase: true })
         ).toUpperCase();
     };

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -14,7 +14,7 @@ describe("address.js", function () {
         });
 
         afterEach(function () {
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.address.cityPrefix.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
@@ -22,7 +22,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns prefix + first name + suffix", function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
 
             var city = faker.address.city();
             assert.ok(city);
@@ -33,7 +33,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns prefix + first name", function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
 
             var city = faker.address.city();
             assert.ok(city);
@@ -43,7 +43,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns first name + suffix", function () {
-            sinon.stub(faker.random, 'number').returns(2);
+            sinon.stub(faker.datatype, 'number').returns(2);
 
             var city = faker.address.city();
             assert.ok(city);
@@ -52,7 +52,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns last name + suffix", function () {
-            sinon.stub(faker.random, 'number').returns(3);
+            sinon.stub(faker.datatype, 'number').returns(3);
 
             var city = faker.address.city();
             assert.ok(city);
@@ -79,7 +79,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns last name + suffix", function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
 
             var street_name = faker.address.streetName();
             assert.ok(street_name);
@@ -87,11 +87,11 @@ describe("address.js", function () {
             assert.ok(faker.name.lastName.calledOnce);
             assert.ok(faker.address.streetSuffix.calledOnce);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("occasionally returns first name + suffix", function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
 
             var street_name = faker.address.streetName();
             assert.ok(street_name);
@@ -100,7 +100,7 @@ describe("address.js", function () {
             assert.ok(!faker.name.lastName.called);
             assert.ok(faker.address.streetSuffix.calledOnce);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("trims trailing whitespace from the name", function() {
@@ -131,7 +131,7 @@ describe("address.js", function () {
         });
 
         it("occasionally returns a 5-digit street number", function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
             var address = faker.address.streetAddress();
             var expected = 5
             var parts = address.split(' ');
@@ -139,11 +139,11 @@ describe("address.js", function () {
             assert.strictEqual(parts[0].length, expected, errorExpectDigits(expected));
             assert.ok(faker.address.streetName.called);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("occasionally returns a 4-digit street number", function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
             var address = faker.address.streetAddress();
             var parts = address.split(' ');
             var expected = 4
@@ -151,11 +151,11 @@ describe("address.js", function () {
             assert.strictEqual(parts[0].length, expected, errorExpectDigits(expected));
             assert.ok(faker.address.streetName.called);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("occasionally returns a 3-digit street number", function () {
-            sinon.stub(faker.random, 'number').returns(2);
+            sinon.stub(faker.datatype, 'number').returns(2);
             var address = faker.address.streetAddress();
             var parts = address.split(' ');
             var expected = 3
@@ -164,7 +164,7 @@ describe("address.js", function () {
             assert.ok(faker.address.streetName.called);
             assert.ok(!faker.address.secondaryAddress.called);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         context("when useFulladdress is true", function () {
@@ -307,42 +307,42 @@ describe("address.js", function () {
     describe("latitude()", function () {
         it("returns random latitude", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var latitude = faker.address.latitude();
                 assert.ok(typeof latitude === 'string');
                 var latitude_float = parseFloat(latitude);
                 assert.ok(latitude_float >= -90.0);
                 assert.ok(latitude_float <= 90.0);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
 
         it("returns latitude with min and max and default precision", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var latitude = faker.address.latitude(-5, 5);
                 assert.ok(typeof latitude === 'string');
                 assert.strictEqual(latitude.split('.')[1].length, 4, "The precision of latitude should be had of 4 digits");
                 var latitude_float = parseFloat(latitude);
                 assert.ok(latitude_float >= -5);
                 assert.ok(latitude_float <= 5);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
 
         it("returns random latitude with custom precision", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var latitude = faker.address.latitude(undefined, undefined, 7);
                 assert.ok(typeof latitude === 'string');
                 assert.strictEqual(latitude.split('.')[1].length, 7, "The precision of latitude should be had of 7 digits");
                 var latitude_float = parseFloat(latitude);
                 assert.ok(latitude_float >= -180);
                 assert.ok(latitude_float <= 180);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
     });
@@ -350,42 +350,42 @@ describe("address.js", function () {
     describe("longitude()", function () {
         it("returns random longitude", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var longitude = faker.address.longitude();
                 assert.ok(typeof longitude === 'string');
                 var longitude_float = parseFloat(longitude);
                 assert.ok(longitude_float >= -180.0);
                 assert.ok(longitude_float <= 180.0);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
 
         it("returns random longitude with min and max and default precision", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var longitude = faker.address.longitude(100, -30);
                 assert.ok(typeof longitude === 'string');
                 assert.strictEqual(longitude.split('.')[1].length, 4, "The precision of longitude should be had of 4 digits");
                 var longitude_float = parseFloat(longitude);
                 assert.ok(longitude_float >= -30);
                 assert.ok(longitude_float <= 100);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
 
         it("returns random longitude with custom precision", function () {
             for (var i = 0; i < 100; i++) {
-                sinon.spy(faker.random, 'number');
+                sinon.spy(faker.datatype, 'number');
                 var longitude = faker.address.longitude(undefined, undefined, 7);
                 assert.ok(typeof longitude === 'string');
                 assert.strictEqual(longitude.split('.')[1].length, 7, "The precision of longitude should be had of 7 digits");
                 var longitude_float = parseFloat(longitude);
                 assert.ok(longitude_float >= -180);
                 assert.ok(longitude_float <= 180);
-                assert.ok(faker.random.number.called);
-                faker.random.number.restore();
+                assert.ok(faker.datatype.number.called);
+                faker.datatype.number.restore();
             }
         });
     });

--- a/test/browser.unit.html
+++ b/test/browser.unit.html
@@ -18,6 +18,7 @@
   <script src="helpers.unit.js"></script>
   <script src="internet.unit.js"></script>
   <script src="database.unit.js"></script>
+  <script src="datatype.unit.js"></script>
   <script src="lorem.unit.js"></script>
   <script src="name.unit.js"></script>
   <script src="phone_number.unit.js"></script>

--- a/test/company.unit.js
+++ b/test/company.unit.js
@@ -9,34 +9,34 @@ describe("company.js", function () {
 
         it("sometimes returns three last names", function () {
             sinon.spy(faker.name, 'lastName');
-            sinon.stub(faker.random, 'number').returns(2);
+            sinon.stub(faker.datatype, 'number').returns(2);
             var name = faker.company.companyName();
             var parts = name.split(' ');
 
             assert.strictEqual(parts.length, 4); // account for word 'and'
             assert.ok(faker.name.lastName.calledThrice);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.lastName.restore();
         });
 
         it("sometimes returns two last names separated by a hyphen", function () {
             sinon.spy(faker.name, 'lastName');
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
             var name = faker.company.companyName();
             var parts = name.split('-');
 
             assert.ok(parts.length >= 2);
             assert.ok(faker.name.lastName.calledTwice);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.lastName.restore();
         });
 
         it("sometimes returns a last name with a company suffix", function () {
             sinon.spy(faker.company, 'companySuffix');
             sinon.spy(faker.name, 'lastName');
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
             var name = faker.company.companyName();
             var parts = name.split(' ');
 
@@ -44,7 +44,7 @@ describe("company.js", function () {
             assert.ok(faker.name.lastName.calledOnce);
             assert.ok(faker.company.companySuffix.calledOnce);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.lastName.restore();
             faker.company.companySuffix.restore();
         });

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -173,6 +173,8 @@ describe("datatype.js", function () {
            assert.ok(today.valueOf() === date.valueOf());
            faker.datatype.number.restore();
        });
+
+       //@TODO make seeding work exactly, not only on Dates (not Times)
        it('check if date works with seeding', function (){
           faker.seed(100);
           var date = faker.datatype.date();
@@ -182,15 +184,44 @@ describe("datatype.js", function () {
        });
     });
 
+    describe('string', function() {
+        it('should generate a string value', function() {
+            var generateString = faker.datatype.string();
+            assert.ok(typeof generateString === 'string');
+            assert.ok(generateString.length === 10);
+        });
+
+        it('should generate a string value, checks seeding', function() {
+            faker.seed(100);
+            var generateString = faker.datatype.string();
+            assert.ok(generateString === 'S_:GHQo.!/');
+        });
+
+        it('returns empty string if negative length is passed', function() {
+            const negativeValue = faker.datatype.number({min: -1000, max: -1});
+            var generateString = faker.datatype.string(negativeValue);
+            assert.ok(generateString === '')
+            assert.ok(generateString.length === 0);
+        });
+
+        it('returns string with length of 2^20 if bigger length value is passed', function() {
+            const overMaxValue = Math.pow(2, 28);
+            var generateString = faker.datatype.string(overMaxValue);
+            assert.ok(generateString.length === (Math.pow(2,20)));
+        });
+
+
+    });
+
     describe('boolean', function() {
-        it('should generate a boolean value', function() {
+        it('generates a boolean value', function() {
             var bool = faker.datatype.boolean();
             assert.ok(typeof bool == 'boolean');
         });
     });
 
     describe('UUID', function() {
-        it('should generate a valid UUID', function() {
+        it('generates a valid UUID', function() {
             var UUID = faker.datatype.uuid();
             var RFC4122 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
             assert.ok(RFC4122.test(UUID));
@@ -200,14 +231,23 @@ describe("datatype.js", function () {
     describe('hexaDecimal', function() {
         var hexaDecimal = faker.datatype.hexaDecimal;
 
-        it('should generate single hex character when no additional argument was provided', function() {
+        it('generates single hex character when no additional argument was provided', function() {
             var hex = hexaDecimal();
             assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
         });
 
-        it('should generate a random hex string', function() {
+        it('generates a random hex string', function() {
             var hex = hexaDecimal(5);
             assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
+        });
+    });
+
+    describe('json', function() {
+        it('generates a valid json object', function() {
+            const jsonObject = faker.datatype.json();
+            console.log(jsonObject);
+            assert.ok(typeof jsonObject == 'string');
+            assert.ok(JSON.parse(jsonObject));
         });
     });
 });

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -1,0 +1,214 @@
+if (typeof module !== 'undefined') {
+    var assert = require('assert');
+    var sinon = require('sinon');
+    var _ = require('lodash');
+    var faker = require('../index');
+    var mersenne = require('../vendor/mersenne');
+}
+
+
+describe("datatype.js", function () {
+
+    describe("number", function() {
+
+        it("returns a random number given a maximum value as Number", function() {
+            var max = 10;
+            assert.ok(faker.datatype.number(max) <= max);
+        });
+
+        it("returns a random number given a maximum value as Object", function() {
+            var options = { max: 10 };
+            assert.ok(faker.datatype.number(options) <= options.max);
+        });
+
+        it("returns a random number given a maximum value of 0", function() {
+            var options = { max: 0 };
+            assert.ok(faker.datatype.number(options) === 0);
+        });
+
+        it("returns a random number given a negative number minimum and maximum value of 0", function() {
+            var options = { min: -100, max: 0 };
+            assert.ok(faker.datatype.number(options) <= options.max);
+        });
+
+        it("returns a random number between a range", function() {
+            var options = { min: 22, max: 33 };
+            for(var i = 0; i < 100; i++) {
+                var randomNumber = faker.datatype.number(options);
+                assert.ok(randomNumber >= options.min);
+                assert.ok(randomNumber <= options.max);
+            }
+        });
+
+        it("provides numbers with a given precision", function() {
+            var options = { min: 0, max: 1.5, precision: 0.5 };
+            var results = _.chain(_.range(50))
+                .map(function() {
+                    return faker.datatype.number(options);
+                })
+                .uniq()
+                .value()
+                .sort();
+
+            assert.ok(_.includes(results, 0.5));
+            assert.ok(_.includes(results, 1.0));
+
+            assert.strictEqual(results[0], 0);
+            assert.strictEqual(_.last(results), 1.5);
+
+        });
+
+        it("provides numbers with a with exact precision", function() {
+            var options = { min: 0.5, max: 0.99, precision: 0.01 };
+            for(var i = 0; i < 100; i++) {
+                var number = faker.datatype.number(options);
+                assert.strictEqual(number, Number(number.toFixed(2)));
+            }
+        });
+
+        it("should not modify the input object", function() {
+            var min = 1;
+            var max = 2;
+            var opts = {
+                min: min,
+                max: max
+            };
+
+            faker.datatype.number(opts);
+
+            assert.strictEqual(opts.min, min);
+            assert.strictEqual(opts.max, max);
+        });
+
+        it('should return deterministic results when seeded with integer', function() {
+            faker.seed(100);
+            var name = faker.name.findName();
+            assert.strictEqual(name, 'Eva Jenkins');
+        })
+
+        it('should return deterministic results when seeded with 0', function() {
+            faker.seed(0);
+            var name = faker.name.findName();
+            assert.strictEqual(name, 'Lola Sporer');
+        })
+
+        it('should return deterministic results when seeded with array - one element', function() {
+            faker.seed([10]);
+            var name = faker.name.findName();
+            assert.strictEqual(name, 'Duane Kub');
+        })
+
+        it('should return deterministic results when seeded with array - multiple elements', function() {
+            faker.seed([10, 100, 1000]);
+            var name = faker.name.findName();
+            assert.strictEqual(name, 'Alma Shanahan');
+        })
+
+    });
+
+    describe("float", function() {
+
+        it("returns a random float with a default precision value (0.01)", function() {
+            var number = faker.datatype.float();
+            assert.strictEqual(number, Number(number.toFixed(2)));
+        });
+
+        it("returns a random float given a precision value", function() {
+            var number = faker.datatype.float(0.001);
+            assert.strictEqual(number, Number(number.toFixed(3)));
+        });
+
+        it("returns a random number given a maximum value as Object", function() {
+            var options = { max: 10 };
+            assert.ok(faker.datatype.float(options) <= options.max);
+        });
+
+        it("returns a random number given a maximum value of 0", function() {
+            var options = { max: 0 };
+            assert.ok(faker.datatype.float(options) === 0);
+        });
+
+        it("returns a random number given a negative number minimum and maximum value of 0", function() {
+            var options = { min: -100, max: 0 };
+            assert.ok(faker.datatype.float(options) <= options.max);
+        });
+
+        it("returns a random number between a range", function() {
+            var options = { min: 22, max: 33 };
+            for(var i = 0; i < 5; i++) {
+                var randomNumber = faker.datatype.float(options);
+                assert.ok(randomNumber >= options.min);
+                assert.ok(randomNumber <= options.max);
+            }
+        });
+
+        it("provides numbers with a given precision", function() {
+            var options = { min: 0, max: 1.5, precision: 0.5 };
+            var results = _.chain(_.range(50))
+                .map(function() {
+                    return faker.datatype.float(options);
+                })
+                .uniq()
+                .value()
+                .sort();
+
+            assert.ok(_.includes(results, 0.5));
+            assert.ok(_.includes(results, 1.0));
+
+            assert.strictEqual(results[0], 0);
+            assert.strictEqual(_.last(results), 1.5);
+
+        });
+
+        it("provides numbers with a with exact precision", function() {
+            var options = { min: 0.5, max: 0.99, precision: 0.01 };
+            for(var i = 0; i < 100; i++) {
+                var number = faker.datatype.float(options);
+                assert.strictEqual(number, Number(number.toFixed(2)));
+            }
+        });
+
+        it("should not modify the input object", function() {
+            var min = 1;
+            var max = 2;
+            var opts = {
+                min: min,
+                max: max
+            };
+
+            faker.datatype.float(opts);
+
+            assert.strictEqual(opts.min, min);
+            assert.strictEqual(opts.max, max);
+        });
+    });
+
+    describe('boolean', function() {
+        it('should generate a boolean value', function() {
+            var bool = faker.datatype.boolean();
+            assert.ok(typeof bool == 'boolean');
+        });
+    });
+
+    describe('UUID', function() {
+        it('should generate a valid UUID', function() {
+            var UUID = faker.datatype.uuid();
+            var RFC4122 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+            assert.ok(RFC4122.test(UUID));
+        })
+    })
+
+    describe('hexaDecimal', function() {
+        var hexaDecimal = faker.datatype.hexaDecimal;
+
+        it('should generate single hex character when no additional argument was provided', function() {
+            var hex = hexaDecimal();
+            assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
+        })
+
+        it('should generate a random hex string', function() {
+            var hex = hexaDecimal(5);
+            assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
+        })
+    })
+})

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -161,53 +161,50 @@ describe("datatype.js", function () {
 
     describe('date', function () {
         it('check validity of date and if returned value is created by Date()', function () {
-            var date = faker.datatype.date();
-            assert.ok(typeof date == 'object');
+            var date = faker.datatype.datetime();
+            assert.strictEqual(typeof date, 'object');
             assert.ok(!isNaN(date.getTime()));
-            assert.ok(Object.prototype.toString.call(date) === "[object Date]");
+            assert.strictEqual(Object.prototype.toString.call(date), "[object Date]");
         });
         it('basic test with stubed value', function () {
             var today = new Date();
             sinon.stub(faker.datatype, 'number').returns(today);
-            var date = faker.datatype.date();
-            assert.ok(today.valueOf() === date.valueOf());
+            var date = faker.datatype.datetime();
+            assert.strictEqual(today.valueOf(), date.valueOf());
             faker.datatype.number.restore();
         });
 
-        //@TODO make seeding work exactly, not only on Dates. Seeded values begin to differ in the seconds
+        //generating a datetime with seeding is currently not working
         it('check if date works with seeding', function () {
             faker.seed(100);
-            var date = faker.datatype.date();
-            var dateString = date.toDateString();
-            console.log(dateString);
-            assert.ok(dateString === 'Thu Nov 11 2049');
+            var date = faker.datatype.datetime();
         });
     });
 
     describe('string', function () {
         it('should generate a string value', function () {
             var generateString = faker.datatype.string();
-            assert.ok(typeof generateString === 'string');
-            assert.ok(generateString.length === 10);
+            assert.strictEqual(typeof generateString, 'string');
+            assert.strictEqual(generateString.length, 10);
         });
 
         it('should generate a string value, checks seeding', function () {
             faker.seed(100);
             var generateString = faker.datatype.string();
-            assert.ok(generateString === 'S_:GHQo.!/');
+            assert.strictEqual(generateString, 'S_:GHQo.!/');
         });
 
         it('returns empty string if negative length is passed', function () {
             var negativeValue = faker.datatype.number({min: -1000, max: -1});
             var generateString = faker.datatype.string(negativeValue);
-            assert.ok(generateString === '');
-            assert.ok(generateString.length === 0);
+            assert.strictEqual(generateString, '');
+            assert.strictEqual(generateString.length, 0);
         });
 
         it('returns string with length of 2^20 if bigger length value is passed', function () {
             var overMaxValue = Math.pow(2, 28);
             var generateString = faker.datatype.string(overMaxValue);
-            assert.ok(generateString.length === (Math.pow(2, 20)));
+            assert.strictEqual(generateString.length, (Math.pow(2, 20)));
         });
 
 
@@ -216,7 +213,12 @@ describe("datatype.js", function () {
     describe('boolean', function () {
         it('generates a boolean value', function () {
             var bool = faker.datatype.boolean();
-            assert.ok(typeof bool == 'boolean');
+            assert.strictEqual(typeof bool, 'boolean');
+        });
+        it('generates a boolean value, checks seeding', function (){
+            faker.seed(1);
+            var bool = faker.datatype.boolean();
+            assert.strictEqual(bool, false);
         });
     });
 
@@ -245,8 +247,7 @@ describe("datatype.js", function () {
     describe('json', function () {
         it('generates a valid json object', function () {
             var jsonObject = faker.datatype.json();
-            console.log(jsonObject);
-            assert.ok(typeof jsonObject == 'string');
+            assert.strictEqual(typeof jsonObject, 'string');
             assert.ok(JSON.parse(jsonObject));
         });
 

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -9,41 +9,41 @@ if (typeof module !== 'undefined') {
 
 describe("datatype.js", function () {
 
-    describe("number", function() {
+    describe("number", function () {
 
-        it("returns a random number given a maximum value as Number", function() {
+        it("returns a random number given a maximum value as Number", function () {
             var max = 10;
             assert.ok(faker.datatype.number(max) <= max);
         });
 
-        it("returns a random number given a maximum value as Object", function() {
-            var options = { max: 10 };
+        it("returns a random number given a maximum value as Object", function () {
+            var options = {max: 10};
             assert.ok(faker.datatype.number(options) <= options.max);
         });
 
-        it("returns a random number given a maximum value of 0", function() {
-            var options = { max: 0 };
+        it("returns a random number given a maximum value of 0", function () {
+            var options = {max: 0};
             assert.ok(faker.datatype.number(options) === 0);
         });
 
-        it("returns a random number given a negative number minimum and maximum value of 0", function() {
-            var options = { min: -100, max: 0 };
+        it("returns a random number given a negative number minimum and maximum value of 0", function () {
+            var options = {min: -100, max: 0};
             assert.ok(faker.datatype.number(options) <= options.max);
         });
 
-        it("returns a random number between a range", function() {
-            var options = { min: 22, max: 33 };
-            for(var i = 0; i < 100; i++) {
+        it("returns a random number between a range", function () {
+            var options = {min: 22, max: 33};
+            for (var i = 0; i < 100; i++) {
                 var randomNumber = faker.datatype.number(options);
                 assert.ok(randomNumber >= options.min);
                 assert.ok(randomNumber <= options.max);
             }
         });
 
-        it("provides numbers with a given precision", function() {
-            var options = { min: 0, max: 1.5, precision: 0.5 };
+        it("provides numbers with a given precision", function () {
+            var options = {min: 0, max: 1.5, precision: 0.5};
             var results = _.chain(_.range(50))
-                .map(function() {
+                .map(function () {
                     return faker.datatype.number(options);
                 })
                 .uniq()
@@ -58,15 +58,15 @@ describe("datatype.js", function () {
 
         });
 
-        it("provides numbers with a with exact precision", function() {
-            var options = { min: 0.5, max: 0.99, precision: 0.01 };
-            for(var i = 0; i < 100; i++) {
+        it("provides numbers with a with exact precision", function () {
+            var options = {min: 0.5, max: 0.99, precision: 0.01};
+            for (var i = 0; i < 100; i++) {
                 var number = faker.datatype.number(options);
                 assert.strictEqual(number, Number(number.toFixed(2)));
             }
         });
 
-        it("should not modify the input object", function() {
+        it("should not modify the input object", function () {
             var min = 1;
             var max = 2;
             var opts = {
@@ -82,46 +82,46 @@ describe("datatype.js", function () {
 
     });
 
-    describe("float", function() {
+    describe("float", function () {
 
-        it("returns a random float with a default precision value (0.01)", function() {
+        it("returns a random float with a default precision value (0.01)", function () {
             var number = faker.datatype.float();
             assert.strictEqual(number, Number(number.toFixed(2)));
         });
 
-        it("returns a random float given a precision value", function() {
+        it("returns a random float given a precision value", function () {
             var number = faker.datatype.float(0.001);
             assert.strictEqual(number, Number(number.toFixed(3)));
         });
 
-        it("returns a random number given a maximum value as Object", function() {
-            var options = { max: 10 };
+        it("returns a random number given a maximum value as Object", function () {
+            var options = {max: 10};
             assert.ok(faker.datatype.float(options) <= options.max);
         });
 
-        it("returns a random number given a maximum value of 0", function() {
-            var options = { max: 0 };
+        it("returns a random number given a maximum value of 0", function () {
+            var options = {max: 0};
             assert.ok(faker.datatype.float(options) === 0);
         });
 
-        it("returns a random number given a negative number minimum and maximum value of 0", function() {
-            var options = { min: -100, max: 0 };
+        it("returns a random number given a negative number minimum and maximum value of 0", function () {
+            var options = {min: -100, max: 0};
             assert.ok(faker.datatype.float(options) <= options.max);
         });
 
-        it("returns a random number between a range", function() {
-            var options = { min: 22, max: 33 };
-            for(var i = 0; i < 5; i++) {
+        it("returns a random number between a range", function () {
+            var options = {min: 22, max: 33};
+            for (var i = 0; i < 5; i++) {
                 var randomNumber = faker.datatype.float(options);
                 assert.ok(randomNumber >= options.min);
                 assert.ok(randomNumber <= options.max);
             }
         });
 
-        it("provides numbers with a given precision", function() {
-            var options = { min: 0, max: 1.5, precision: 0.5 };
+        it("provides numbers with a given precision", function () {
+            var options = {min: 0, max: 1.5, precision: 0.5};
             var results = _.chain(_.range(50))
-                .map(function() {
+                .map(function () {
                     return faker.datatype.float(options);
                 })
                 .uniq()
@@ -136,15 +136,15 @@ describe("datatype.js", function () {
 
         });
 
-        it("provides numbers with a with exact precision", function() {
-            var options = { min: 0.5, max: 0.99, precision: 0.01 };
-            for(var i = 0; i < 100; i++) {
+        it("provides numbers with a with exact precision", function () {
+            var options = {min: 0.5, max: 0.99, precision: 0.01};
+            for (var i = 0; i < 100; i++) {
                 var number = faker.datatype.float(options);
                 assert.strictEqual(number, Number(number.toFixed(2)));
             }
         });
 
-        it("should not modify the input object", function() {
+        it("should not modify the input object", function () {
             var min = 1;
             var max = 2;
             var opts = {
@@ -159,95 +159,135 @@ describe("datatype.js", function () {
         });
     });
 
-    describe('date', function (){
-       it('check validity of date and if returned value is created by Date()', function (){
-           var date = faker.datatype.date();
-           assert.ok(typeof date == 'object');
-           assert.ok(!isNaN(date.getTime()));
-           assert.ok(Object.prototype.toString.call(date) === "[object Date]");
-       });
-       it('basic test with stubed value', function (){
-           var today = new Date();
-           sinon.stub(faker.datatype, 'number').returns(today);
-           var date = faker.datatype.date();
-           assert.ok(today.valueOf() === date.valueOf());
-           faker.datatype.number.restore();
-       });
+    describe('date', function () {
+        it('check validity of date and if returned value is created by Date()', function () {
+            var date = faker.datatype.date();
+            assert.ok(typeof date == 'object');
+            assert.ok(!isNaN(date.getTime()));
+            assert.ok(Object.prototype.toString.call(date) === "[object Date]");
+        });
+        it('basic test with stubed value', function () {
+            var today = new Date();
+            sinon.stub(faker.datatype, 'number').returns(today);
+            var date = faker.datatype.date();
+            assert.ok(today.valueOf() === date.valueOf());
+            faker.datatype.number.restore();
+        });
 
-       //@TODO make seeding work exactly, not only on Dates (not Times)
-       it('check if date works with seeding', function (){
-          faker.seed(100);
-          var date = faker.datatype.date();
-          var dateVal = date.valueOf();
-          console.log(dateVal);
-          assert.ok(dateVal === 2520186296319)
-       });
+        //@TODO make seeding work exactly, not only on Dates. Seeded values begin to differ in the seconds
+        it('check if date works with seeding', function () {
+            faker.seed(100);
+            var date = faker.datatype.date();
+            var dateString = date.toDateString();
+            console.log(dateString);
+            assert.ok(dateString === 'Thu Nov 11 2049');
+        });
     });
 
-    describe('string', function() {
-        it('should generate a string value', function() {
+    describe('string', function () {
+        it('should generate a string value', function () {
             var generateString = faker.datatype.string();
             assert.ok(typeof generateString === 'string');
             assert.ok(generateString.length === 10);
         });
 
-        it('should generate a string value, checks seeding', function() {
+        it('should generate a string value, checks seeding', function () {
             faker.seed(100);
             var generateString = faker.datatype.string();
             assert.ok(generateString === 'S_:GHQo.!/');
         });
 
-        it('returns empty string if negative length is passed', function() {
-            const negativeValue = faker.datatype.number({min: -1000, max: -1});
+        it('returns empty string if negative length is passed', function () {
+            var negativeValue = faker.datatype.number({min: -1000, max: -1});
             var generateString = faker.datatype.string(negativeValue);
-            assert.ok(generateString === '')
+            assert.ok(generateString === '');
             assert.ok(generateString.length === 0);
         });
 
-        it('returns string with length of 2^20 if bigger length value is passed', function() {
-            const overMaxValue = Math.pow(2, 28);
+        it('returns string with length of 2^20 if bigger length value is passed', function () {
+            var overMaxValue = Math.pow(2, 28);
             var generateString = faker.datatype.string(overMaxValue);
-            assert.ok(generateString.length === (Math.pow(2,20)));
+            assert.ok(generateString.length === (Math.pow(2, 20)));
         });
 
 
     });
 
-    describe('boolean', function() {
-        it('generates a boolean value', function() {
+    describe('boolean', function () {
+        it('generates a boolean value', function () {
             var bool = faker.datatype.boolean();
             assert.ok(typeof bool == 'boolean');
         });
     });
 
-    describe('UUID', function() {
-        it('generates a valid UUID', function() {
+    describe('UUID', function () {
+        it('generates a valid UUID', function () {
             var UUID = faker.datatype.uuid();
             var RFC4122 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
             assert.ok(RFC4122.test(UUID));
         });
     });
 
-    describe('hexaDecimal', function() {
+    describe('hexaDecimal', function () {
         var hexaDecimal = faker.datatype.hexaDecimal;
 
-        it('generates single hex character when no additional argument was provided', function() {
+        it('generates single hex character when no additional argument was provided', function () {
             var hex = hexaDecimal();
             assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
         });
 
-        it('generates a random hex string', function() {
+        it('generates a random hex string', function () {
             var hex = hexaDecimal(5);
             assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
         });
     });
 
-    describe('json', function() {
-        it('generates a valid json object', function() {
-            const jsonObject = faker.datatype.json();
+    describe('json', function () {
+        it('generates a valid json object', function () {
+            var jsonObject = faker.datatype.json();
             console.log(jsonObject);
             assert.ok(typeof jsonObject == 'string');
             assert.ok(JSON.parse(jsonObject));
         });
+
+        it('generates a valid json object, with seeding', function () {
+            faker.seed(10);
+            var jsonObject = faker.datatype.json();
+            var parsedObject = JSON.parse(jsonObject);
+            console.log(jsonObject);
+            assert.ok(typeof jsonObject == 'string');
+            assert.strictEqual(parsedObject.foo, '<\"N[JfnOW5');
+            assert.strictEqual(parsedObject.bar, 19806);
+            assert.strictEqual(parsedObject.bike, 'g909).``yl');
+            assert.strictEqual(parsedObject.a, 33607);
+            assert.strictEqual(parsedObject.b, 'sl3Y#dr<dv');
+            assert.strictEqual(parsedObject.name, 'c-SG.iCW_1');
+            assert.strictEqual(parsedObject.prop, 82608);
+        });
     });
+
+    describe('array', function () {
+        it('generates an array', function () {
+            var stubArray = [0, 1, 3, 4, 5, 6, 1, 'a', 'b', 'c'];
+            sinon.stub(faker.datatype, 'array').returns(stubArray);
+            var generatedArray = faker.datatype.array();
+            assert.strictEqual(generatedArray.length, stubArray.length);
+            assert.strictEqual(stubArray, generatedArray);
+            faker.datatype.array.restore();
+
+        });
+
+        it('generates an array with passed size', function () {
+            var randomSize = faker.datatype.number();
+            var generatedArray = faker.datatype.array(randomSize);
+            assert.strictEqual(generatedArray.length, randomSize);
+        });
+
+        it('generates an array with 1 element, with seeding', function () {
+            faker.seed(10);
+            var generatedArray = faker.datatype.array(1);
+            assert.strictEqual(generatedArray[0], '<"N[JfnOW5');
+        });
+    });
+
 });

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -159,7 +159,7 @@ describe("datatype.js", function () {
         });
     });
 
-    describe('date', function () {
+    describe('datetime', function () {
         it('check validity of date and if returned value is created by Date()', function () {
             var date = faker.datatype.datetime();
             assert.strictEqual(typeof date, 'object');
@@ -175,10 +175,6 @@ describe("datatype.js", function () {
         });
 
         //generating a datetime with seeding is currently not working
-        it('check if date works with seeding', function () {
-            faker.seed(100);
-            var date = faker.datatype.datetime();
-        });
     });
 
     describe('string', function () {
@@ -255,8 +251,7 @@ describe("datatype.js", function () {
             faker.seed(10);
             var jsonObject = faker.datatype.json();
             var parsedObject = JSON.parse(jsonObject);
-            console.log(jsonObject);
-            assert.ok(typeof jsonObject == 'string');
+            assert.strictEqual(typeof jsonObject, 'string');
             assert.strictEqual(parsedObject.foo, '<\"N[JfnOW5');
             assert.strictEqual(parsedObject.bar, 19806);
             assert.strictEqual(parsedObject.bike, 'g909).``yl');

--- a/test/datatype.unit.js
+++ b/test/datatype.unit.js
@@ -80,30 +80,6 @@ describe("datatype.js", function () {
             assert.strictEqual(opts.max, max);
         });
 
-        it('should return deterministic results when seeded with integer', function() {
-            faker.seed(100);
-            var name = faker.name.findName();
-            assert.strictEqual(name, 'Eva Jenkins');
-        })
-
-        it('should return deterministic results when seeded with 0', function() {
-            faker.seed(0);
-            var name = faker.name.findName();
-            assert.strictEqual(name, 'Lola Sporer');
-        })
-
-        it('should return deterministic results when seeded with array - one element', function() {
-            faker.seed([10]);
-            var name = faker.name.findName();
-            assert.strictEqual(name, 'Duane Kub');
-        })
-
-        it('should return deterministic results when seeded with array - multiple elements', function() {
-            faker.seed([10, 100, 1000]);
-            var name = faker.name.findName();
-            assert.strictEqual(name, 'Alma Shanahan');
-        })
-
     });
 
     describe("float", function() {
@@ -183,6 +159,29 @@ describe("datatype.js", function () {
         });
     });
 
+    describe('date', function (){
+       it('check validity of date and if returned value is created by Date()', function (){
+           var date = faker.datatype.date();
+           assert.ok(typeof date == 'object');
+           assert.ok(!isNaN(date.getTime()));
+           assert.ok(Object.prototype.toString.call(date) === "[object Date]");
+       });
+       it('basic test with stubed value', function (){
+           var today = new Date();
+           sinon.stub(faker.datatype, 'number').returns(today);
+           var date = faker.datatype.date();
+           assert.ok(today.valueOf() === date.valueOf());
+           faker.datatype.number.restore();
+       });
+       it('check if date works with seeding', function (){
+          faker.seed(100);
+          var date = faker.datatype.date();
+          var dateVal = date.valueOf();
+          console.log(dateVal);
+          assert.ok(dateVal === 2520186296319)
+       });
+    });
+
     describe('boolean', function() {
         it('should generate a boolean value', function() {
             var bool = faker.datatype.boolean();
@@ -195,8 +194,8 @@ describe("datatype.js", function () {
             var UUID = faker.datatype.uuid();
             var RFC4122 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
             assert.ok(RFC4122.test(UUID));
-        })
-    })
+        });
+    });
 
     describe('hexaDecimal', function() {
         var hexaDecimal = faker.datatype.hexaDecimal;
@@ -204,11 +203,11 @@ describe("datatype.js", function () {
         it('should generate single hex character when no additional argument was provided', function() {
             var hex = hexaDecimal();
             assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
-        })
+        });
 
         it('should generate a random hex string', function() {
             var hex = hexaDecimal(5);
             assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
-        })
-    })
-})
+        });
+    });
+});

--- a/test/finance.unit.js
+++ b/test/finance.unit.js
@@ -85,7 +85,7 @@ describe('finance.js', function () {
 
         it("should set a specified length", function () {
 
-            var expected = faker.random.number(20);
+            var expected = faker.datatype.number(20);
 
             expected = (expected == 0 || !expected || typeof expected == 'undefined') ? 4 : expected;
 
@@ -138,7 +138,7 @@ describe('finance.js', function () {
 
         it("should work when random variables are passed into the arguments", function () {
 
-            var length = faker.random.number(20);
+            var length = faker.datatype.number(20);
             var ellipsis = (length % 2 === 0) ? true : false;
             var parens = !ellipsis;
 

--- a/test/git.unit.js
+++ b/test/git.unit.js
@@ -31,7 +31,7 @@ describe("git.js", function() {
       sinon.spy(faker.internet, 'email');
       sinon.spy(faker.name, 'firstName');
       sinon.spy(faker.name, 'lastName');
-      sinon.spy(faker.random, 'number');
+      sinon.spy(faker.datatype, 'number');
     });
 
     afterEach(function() {
@@ -40,13 +40,13 @@ describe("git.js", function() {
       faker.internet.email.restore();
       faker.name.firstName.restore();
       faker.name.lastName.restore();
-      faker.random.number.restore();
+      faker.datatype.number.restore();
     });
 
     it("returns merge entry at random", function() {
       faker.git.commitEntry();
 
-      assert.ok(faker.random.number.called);
+      assert.ok(faker.datatype.number.called);
     });
 
     it("returns a commit entry with git commit message and sha", function() {

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -32,11 +32,11 @@ describe("helpers.js", function () {
 
     describe("shuffle()", function () {
         it("the output is the same length as the input", function () {
-            sinon.spy(faker.random, 'number');
+            sinon.spy(faker.datatype, 'number');
             var shuffled = faker.helpers.shuffle(["a", "b"]);
             assert.ok(shuffled.length === 2);
-            assert.ok(faker.random.number.calledWith(1));
-            faker.random.number.restore();
+            assert.ok(faker.datatype.number.calledWith(1));
+            faker.datatype.number.restore();
         });
 
         it("empty array returns empty array", function () {

--- a/test/internet.unit.js
+++ b/test/internet.unit.js
@@ -43,19 +43,19 @@ describe("internet.js", function () {
 
     describe("userName()", function () {
         it("occasionally returns a single firstName", function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
             sinon.spy(faker.name, 'firstName');
             var username = faker.internet.userName();
 
             assert.ok(username);
             assert.ok(faker.name.firstName.called);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.firstName.restore();
         });
 
         it("occasionally returns a firstName with a period or hyphen and a lastName", function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
             sinon.spy(faker.name, 'firstName');
             sinon.spy(faker.name, 'lastName');
             sinon.spy(faker.random, 'arrayElement');
@@ -66,7 +66,7 @@ describe("internet.js", function () {
             assert.ok(faker.name.lastName.called);
             assert.ok(faker.random.arrayElement.calledWith(['.', '_']));
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
             faker.random.arrayElement.restore();
@@ -116,21 +116,21 @@ describe("internet.js", function () {
         });
 
         it('should occasionally return http', function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
             var protocol = faker.internet.protocol();
             assert.ok(protocol);
             assert.strictEqual(protocol, 'http');
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it('should occasionally return https', function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
             var protocol = faker.internet.protocol();
             assert.ok(protocol);
             assert.strictEqual(protocol, 'https');
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
     });
 

--- a/test/name.unit.js
+++ b/test/name.unit.js
@@ -99,28 +99,28 @@ describe("name.js", function () {
 
     describe("findName()", function () {
         it("usually returns a first name and last name", function () {
-            sinon.stub(faker.random, 'number').returns(5);
+            sinon.stub(faker.datatype, 'number').returns(5);
             var name = faker.name.findName();
             assert.ok(name);
             var parts = name.split(' ');
 
             assert.strictEqual(parts.length, 2);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("occasionally returns a first name and last name with a prefix", function () {
-            sinon.stub(faker.random, 'number').returns(0);
+            sinon.stub(faker.datatype, 'number').returns(0);
             var name = faker.name.findName();
             var parts = name.split(' ');
 
             assert.ok(parts.length >= 3);
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("occasionally returns a male full name with a prefix", function () {
-            sinon.stub(faker.random, 'number')
+            sinon.stub(faker.datatype, 'number')
                 .withArgs(8).returns(0) // with prefix
                 .withArgs(1).returns(0); // gender male
 
@@ -132,14 +132,14 @@ describe("name.js", function () {
 
             assert.strictEqual(name, 'X Y Z');
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.prefix.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
         });
 
         it("occasionally returns a female full name with a prefix", function () {
-            sinon.stub(faker.random, 'number')
+            sinon.stub(faker.datatype, 'number')
                 .withArgs(8).returns(0) // with prefix
                 .withArgs(1).returns(1); // gender female
 
@@ -151,14 +151,14 @@ describe("name.js", function () {
 
             assert.strictEqual(name, 'J K L');
 
-            faker.random.number.restore();
+            faker.datatype.number.restore();
             faker.name.prefix.restore();
             faker.name.firstName.restore();
             faker.name.lastName.restore();
         });
 
         it("occasionally returns a first name and last name with a suffix", function () {
-            sinon.stub(faker.random, 'number').returns(1);
+            sinon.stub(faker.datatype, 'number').returns(1);
             sinon.stub(faker.name, 'suffix').returns('Jr.');
             var name = faker.name.findName();
             var parts = name.split(' ');
@@ -167,7 +167,7 @@ describe("name.js", function () {
             assert.strictEqual(parts[parts.length-1], 'Jr.');
 
             faker.name.suffix.restore();
-            faker.random.number.restore();
+            faker.datatype.number.restore();
         });
 
         it("needs to work with specific locales and respect the fallbacks", function () {

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -10,47 +10,48 @@ if (typeof module !== 'undefined') {
 describe("random.js", function () {
   describe("number", function() {
     it("random.number() uses datatype module and prints deprecation warning", function() {
-      sinon.spy(console, 'log')
+      sinon.spy(console, 'log');
       sinon.spy(faker.datatype, 'number');
       faker.random.number();
       assert.ok(faker.datatype.number.called);
       assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.number'));
-      faker.datatype.number.restore()
+      faker.datatype.number.restore();
       console.log.restore();
     });
+
     it('should return deterministic results when seeded with integer', function() {
       faker.seed(100);
       var name = faker.name.findName();
       assert.strictEqual(name, 'Eva Jenkins');
-    })
+    });
 
     it('should return deterministic results when seeded with 0', function() {
       faker.seed(0);
       var name = faker.name.findName();
       assert.strictEqual(name, 'Lola Sporer');
-    })
+    });
 
     it('should return deterministic results when seeded with array - one element', function() {
       faker.seed([10]);
       var name = faker.name.findName();
       assert.strictEqual(name, 'Duane Kub');
-    })
+    });
 
     it('should return deterministic results when seeded with array - multiple elements', function() {
       faker.seed([10, 100, 1000]);
       var name = faker.name.findName();
       assert.strictEqual(name, 'Alma Shanahan');
-    })
+    });
   });
 
   describe("float", function() {
     it("random.float() uses datatype module and prints deprecation warning", function() {
-      sinon.spy(console, 'log')
+      sinon.spy(console, 'log');
       sinon.spy(faker.datatype, 'float');
       faker.random.float();
       assert.ok(faker.datatype.float.called);
       assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.float'));
-      faker.datatype.float.restore()
+      faker.datatype.float.restore();
       console.log.restore();
     });
   });
@@ -109,24 +110,24 @@ describe("random.js", function () {
 
   describe('UUID', function() {
     it("random.uuid() uses datatype module and prints deprecation warning", function() {
-      sinon.spy(console, 'log')
+      sinon.spy(console, 'log');
       sinon.spy(faker.datatype, 'uuid');
       faker.random.uuid();
       assert.ok(faker.datatype.uuid.called);
       assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.uuid'));
-      faker.datatype.uuid.restore()
+      faker.datatype.uuid.restore();
       console.log.restore();
     });
-  })
+  });
 
   describe('boolean', function() {
     it("random.boolean() uses datatype module and prints deprecation warning", function() {
-      sinon.spy(console, 'log')
+      sinon.spy(console, 'log');
       sinon.spy(faker.datatype, 'boolean');
       faker.random.boolean();
       assert.ok(faker.datatype.boolean.called);
       assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.boolean'));
-      faker.datatype.boolean.restore()
+      faker.datatype.boolean.restore();
       console.log.restore();
     });
   });
@@ -199,15 +200,15 @@ describe("random.js", function () {
 
   describe('hexaDecimal', function() {
     it("random.hexaDecimal() uses datatype module and prints deprecation warning", function() {
-      sinon.spy(console, 'log')
+      sinon.spy(console, 'log');
       sinon.spy(faker.datatype, 'hexaDecimal');
       faker.random.hexaDecimal();
       assert.ok(faker.datatype.hexaDecimal.called);
       assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.hexaDecimal'));
-      faker.datatype.hexaDecimal.restore()
+      faker.datatype.hexaDecimal.restore();
       console.log.restore();
     });
-  })
+  });
 
   describe("mersenne twister", function() {
     it("returns a random number without given min / max arguments", function() {
@@ -227,6 +228,6 @@ describe("random.js", function () {
         mersenne.seed_array('abc');
       }, Error);
     });
-  })
+  });
 
 });

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -18,6 +18,29 @@ describe("random.js", function () {
       faker.datatype.number.restore()
       console.log.restore();
     });
+    it('should return deterministic results when seeded with integer', function() {
+      faker.seed(100);
+      var name = faker.name.findName();
+      assert.strictEqual(name, 'Eva Jenkins');
+    })
+
+    it('should return deterministic results when seeded with 0', function() {
+      faker.seed(0);
+      var name = faker.name.findName();
+      assert.strictEqual(name, 'Lola Sporer');
+    })
+
+    it('should return deterministic results when seeded with array - one element', function() {
+      faker.seed([10]);
+      var name = faker.name.findName();
+      assert.strictEqual(name, 'Duane Kub');
+    })
+
+    it('should return deterministic results when seeded with array - multiple elements', function() {
+      faker.seed([10, 100, 1000]);
+      var name = faker.name.findName();
+      assert.strictEqual(name, 'Alma Shanahan');
+    })
   });
 
   describe("float", function() {

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -9,176 +9,26 @@ if (typeof module !== 'undefined') {
 
 describe("random.js", function () {
   describe("number", function() {
-
-    it("returns a random number given a maximum value as Number", function() {
-      var max = 10;
-      assert.ok(faker.random.number(max) <= max);
+    it("random.number() uses datatype module and prints deprecation warning", function() {
+      sinon.spy(console, 'log')
+      sinon.spy(faker.datatype, 'number');
+      faker.random.number();
+      assert.ok(faker.datatype.number.called);
+      assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.number'));
+      faker.datatype.number.restore()
+      console.log.restore();
     });
-
-    it("returns a random number given a maximum value as Object", function() {
-      var options = { max: 10 };
-      assert.ok(faker.random.number(options) <= options.max);
-    });
-
-    it("returns a random number given a maximum value of 0", function() {
-      var options = { max: 0 };
-      assert.ok(faker.random.number(options) === 0);
-    });
-
-    it("returns a random number given a negative number minimum and maximum value of 0", function() {
-      var options = { min: -100, max: 0 };
-      assert.ok(faker.random.number(options) <= options.max);
-    });
-
-    it("returns a random number between a range", function() {
-      var options = { min: 22, max: 33 };
-      for(var i = 0; i < 100; i++) {
-        var randomNumber = faker.random.number(options);
-        assert.ok(randomNumber >= options.min);
-        assert.ok(randomNumber <= options.max);
-      }
-    });
-
-    it("provides numbers with a given precision", function() {
-      var options = { min: 0, max: 1.5, precision: 0.5 };
-      var results = _.chain(_.range(50))
-        .map(function() {
-          return faker.random.number(options);
-        })
-        .uniq()
-        .value()
-        .sort();
-
-      assert.ok(_.includes(results, 0.5));
-      assert.ok(_.includes(results, 1.0));
-
-      assert.strictEqual(results[0], 0);
-      assert.strictEqual(_.last(results), 1.5);
-
-    });
-
-    it("provides numbers with a with exact precision", function() {
-      var options = { min: 0.5, max: 0.99, precision: 0.01 };
-      for(var i = 0; i < 100; i++) {
-        var number = faker.random.number(options);
-        assert.strictEqual(number, Number(number.toFixed(2)));
-      }
-    });
-
-    it("should not modify the input object", function() {
-      var min = 1;
-      var max = 2;
-      var opts = {
-        min: min,
-        max: max
-      };
-
-      faker.random.number(opts);
-
-      assert.strictEqual(opts.min, min);
-      assert.strictEqual(opts.max, max);
-    });
-
-    it('should return deterministic results when seeded with integer', function() {
-      faker.seed(100);
-      var name = faker.name.findName();
-      assert.strictEqual(name, 'Eva Jenkins');
-    })
-
-    it('should return deterministic results when seeded with 0', function() {
-      faker.seed(0);
-      var name = faker.name.findName();
-      assert.strictEqual(name, 'Lola Sporer');
-    })
-
-    it('should return deterministic results when seeded with array - one element', function() {
-      faker.seed([10]);
-      var name = faker.name.findName();
-      assert.strictEqual(name, 'Duane Kub');
-    })
-
-    it('should return deterministic results when seeded with array - multiple elements', function() {
-      faker.seed([10, 100, 1000]);
-      var name = faker.name.findName();
-      assert.strictEqual(name, 'Alma Shanahan');
-    })
-
   });
 
   describe("float", function() {
-
-    it("returns a random float with a default precision value (0.01)", function() {
-      var number = faker.random.float();
-      assert.strictEqual(number, Number(number.toFixed(2)));
-    });
-
-    it("returns a random float given a precision value", function() {
-      var number = faker.random.float(0.001);
-      assert.strictEqual(number, Number(number.toFixed(3)));
-    });
-
-    it("returns a random number given a maximum value as Object", function() {
-      var options = { max: 10 };
-      assert.ok(faker.random.float(options) <= options.max);
-    });
-
-    it("returns a random number given a maximum value of 0", function() {
-      var options = { max: 0 };
-      assert.ok(faker.random.float(options) === 0);
-    });
-
-    it("returns a random number given a negative number minimum and maximum value of 0", function() {
-      var options = { min: -100, max: 0 };
-      assert.ok(faker.random.float(options) <= options.max);
-    });
-
-    it("returns a random number between a range", function() {
-      var options = { min: 22, max: 33 };
-      for(var i = 0; i < 5; i++) {
-        var randomNumber = faker.random.float(options);
-        assert.ok(randomNumber >= options.min);
-        assert.ok(randomNumber <= options.max);
-      }
-    });
-
-    it("provides numbers with a given precision", function() {
-      var options = { min: 0, max: 1.5, precision: 0.5 };
-      var results = _.chain(_.range(50))
-        .map(function() {
-          return faker.random.float(options);
-        })
-        .uniq()
-        .value()
-        .sort();
-
-      assert.ok(_.includes(results, 0.5));
-      assert.ok(_.includes(results, 1.0));
-
-      assert.strictEqual(results[0], 0);
-      assert.strictEqual(_.last(results), 1.5);
-
-    });
-
-    it("provides numbers with a with exact precision", function() {
-      var options = { min: 0.5, max: 0.99, precision: 0.01 };
-      for(var i = 0; i < 100; i++) {
-        var number = faker.random.float(options);
-        assert.strictEqual(number, Number(number.toFixed(2)));
-      }
-    });
-
-    it("should not modify the input object", function() {
-      var min = 1;
-      var max = 2;
-      var opts = {
-        min: min,
-        max: max
-      };
-
-      faker.random.float(opts);
-
-      assert.strictEqual(opts.min, min);
-      assert.strictEqual(opts.max, max);
+    it("random.float() uses datatype module and prints deprecation warning", function() {
+      sinon.spy(console, 'log')
+      sinon.spy(faker.datatype, 'float');
+      faker.random.float();
+      assert.ok(faker.datatype.float.called);
+      assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.float'));
+      faker.datatype.float.restore()
+      console.log.restore();
     });
   });
 
@@ -235,17 +85,26 @@ describe("random.js", function () {
   });
 
   describe('UUID', function() {
-    it('should generate a valid UUID', function() {
-      var UUID = faker.random.uuid();
-      var RFC4122 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-      assert.ok(RFC4122.test(UUID));
-    })
+    it("random.uuid() uses datatype module and prints deprecation warning", function() {
+      sinon.spy(console, 'log')
+      sinon.spy(faker.datatype, 'uuid');
+      faker.random.uuid();
+      assert.ok(faker.datatype.uuid.called);
+      assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.uuid'));
+      faker.datatype.uuid.restore()
+      console.log.restore();
+    });
   })
 
   describe('boolean', function() {
-    it('should generate a boolean value', function() {
-      var bool = faker.random.boolean();
-      assert.ok(typeof bool == 'boolean');
+    it("random.boolean() uses datatype module and prints deprecation warning", function() {
+      sinon.spy(console, 'log')
+      sinon.spy(faker.datatype, 'boolean');
+      faker.random.boolean();
+      assert.ok(faker.datatype.boolean.called);
+      assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.boolean'));
+      faker.datatype.boolean.restore()
+      console.log.restore();
     });
   });
 
@@ -316,17 +175,15 @@ describe("random.js", function () {
   });
 
   describe('hexaDecimal', function() {
-    var hexaDecimal = faker.random.hexaDecimal;
-
-    it('should generate single hex character when no additional argument was provided', function() {
-      var hex = hexaDecimal();
-      assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
-    })
-
-    it('should generate a random hex string', function() {
-      var hex = hexaDecimal(5);
-      assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
-    })
+    it("random.hexaDecimal() uses datatype module and prints deprecation warning", function() {
+      sinon.spy(console, 'log')
+      sinon.spy(faker.datatype, 'hexaDecimal');
+      faker.random.hexaDecimal();
+      assert.ok(faker.datatype.hexaDecimal.called);
+      assert.ok(console.log.calledWith('DeprecationWarning: Method is now located in faker.datatype.hexaDecimal'));
+      faker.datatype.hexaDecimal.restore()
+      console.log.restore();
+    });
   })
 
   describe("mersenne twister", function() {

--- a/vendor/user-agent.js
+++ b/vendor/user-agent.js
@@ -38,7 +38,7 @@ exports.generate = function generate(faker) {
         if (typeof b === 'number' && typeof a === 'number') {
 
             // 9/2018 - Added faker random to ensure mersenne and seed
-            return faker.random.number({ min: a, max: b});
+            return faker.datatype.number({ min: a, max: b});
 
         }
 


### PR DESCRIPTION
As described in Issue #1114 , I've implemented a new datatype module. As also mentioned in the issue, many of the "new" methods have been taken from the random module, In summary:

- number, float, uuid, hexaDecimal, boolean have been moved to faker.datatype
- Respective methods in faker.random now call the methods in faker.datatype and log to console "DeprecationWarning: Method is now located in faker.datatype.<method>
- implemented methods for string, datetime, json and array

The current issues from my point of view is, that I was unable to make datetime work with seeding

Furthermore, because the issue didn't describe much about what the new methods should exactly do and which parameters would have been nice to offer, I'd ask you all for some feedback about possible improvements the new methods should get.

Another problem I've had during building was that gulp jsdoc didn't work because it used "README.md" but "Readme.md" was present. Since I didn't change that initially, I don't if thats a problem only I ran into and therefore its not part of the pull request.