### PR TITLE
Hexadecimal cleanup

### DIFF
--- a/lib/finance.js
+++ b/lib/finance.js
@@ -247,7 +247,7 @@ self.litecoinAddress = function () {
    * @method  faker.finance.ethereumAddress
    */
   self.ethereumAddress = function () {
-    var address = faker.random.hexaDecimal(40).toLowerCase();
+    var address = faker.random.hexaDecimal(40);
 
     return address;
   };

--- a/lib/git.js
+++ b/lib/git.js
@@ -55,7 +55,7 @@ var Git = function(faker) {
    * @method faker.git.commitSha
    */
   self.commitSha = function() {
-    return faker.random.hexaDecimal(40, false, false);
+    return faker.random.hexaDecimal(40, false);
   };
 
   /**
@@ -64,7 +64,7 @@ var Git = function(faker) {
    * @method faker.git.shortSha
    */
   self.shortSha = function() {
-    return faker.random.hexaDecimal(7, false, false);
+    return faker.random.hexaDecimal(7, false);
   };
 
   return self;

--- a/lib/git.js
+++ b/lib/git.js
@@ -6,8 +6,6 @@ var Git = function(faker) {
   var self = this;
   var f = faker.fake;
 
-  var hexChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
-
   /**
    * branch
    *
@@ -57,13 +55,7 @@ var Git = function(faker) {
    * @method faker.git.commitSha
    */
   self.commitSha = function() {
-    var commit = "";
-
-    for (var i = 0; i < 40; i++) {
-      commit += faker.random.arrayElement(hexChars);
-    }
-
-    return commit;
+    return faker.random.hexaDecimal(40, false, false);
   };
 
   /**
@@ -72,13 +64,7 @@ var Git = function(faker) {
    * @method faker.git.shortSha
    */
   self.shortSha = function() {
-    var shortSha = "";
-
-    for (var i = 0; i < 7; i++) {
-      shortSha += faker.random.arrayElement(hexChars);
-    }
-
-    return shortSha;
+    return faker.random.hexaDecimal(7, false, false);
   };
 
   return self;

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -235,11 +235,7 @@ var Internet = function (faker) {
    */
   self.ipv6 = function () {
       var randHash = function () {
-          var result = "";
-          for (var i = 0; i < 4; i++) {
-            result += (faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]));
-          }
-          return result
+        return faker.random.hexaDecimal(4, false);
       };
 
       var result = [];

--- a/lib/random.js
+++ b/lib/random.js
@@ -331,18 +331,26 @@ function Random (faker, seed) {
    *
    * @method faker.random.hexaDecimal
    * @param {number} count defaults to 1
+   * @param {boolean} prefix with `"0x"`. defaults to true
    */
-  this.hexaDecimal = function hexaDecimal(count) {
+  this.hexaDecimal = function hexaDecimal(count, prefix) {
     if (typeof count === "undefined") {
       count = 1;
     }
-
-    var wholeString = "";
-    for(var i = 0; i < count; i++) {
-      wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F"]);
+    if (typeof prefix === "undefined") {
+        prefix = true;
     }
 
-    return "0x"+wholeString;
+    var wholeString = "";
+    for (var i = 0; i < count; i++) {
+      wholeString += faker.random.arrayElement(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]);
+    }
+
+    if (prefix === true) {
+        wholeString = "0x"+wholeString;
+    }
+
+    return wholeString;
   };
 
   return this;

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -320,12 +320,12 @@ describe("random.js", function () {
 
     it('should generate single hex character when no additional argument was provided', function() {
       var hex = hexaDecimal();
-      assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/i));
+      assert.ok(hex.match(/^(0x)[0-9a-f]{1}$/));
     })
 
     it('should generate a random hex string', function() {
       var hex = hexaDecimal(5);
-      assert.ok(hex.match(/^(0x)[0-9a-f]+$/i));
+      assert.ok(hex.match(/^(0x)[0-9a-f]{5}$/));
     })
   })
 


### PR DESCRIPTION
* Added an optional `prefix` parameter to `hexaDecimal` which defaults to true, to keep it backwards compatible.
* Use 1 source for hexadecimal characters for several usages (internet, git, finance).
* Removed the uppercase characters as the tests ignored them anyway and the only existing `hexaDecimal` usage used a `toLowerCase()`
* Made tests more strict

Other thoughts: make upper-, lower- & mixed case options available.