### PR TITLE
use city definitions when generating cities

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -49,7 +49,11 @@ function Address (faker) {
    * method provided by faker wrapped in `{{}}`, e.g. `{{name.firstName}}` in
    * order to build the city name.
    *
-   * If no format string is provided one of the following is randomly used:
+   *
+   * If no format string is provided one it is randomly picked from the active
+   * locale 'city.js' fjle.
+   * If the current locale does not have any format defined, the format is
+   * randomly picked from these formats.
    *
    * * `{{address.cityPrefix}} {{name.firstName}}{{address.citySuffix}}`
    * * `{{address.cityPrefix}} {{name.firstName}}`
@@ -61,6 +65,7 @@ function Address (faker) {
    * @param {String} format
    */
   this.city = function (format) {
+    var matchingLocaleFormats = faker.definitions.address.city;
     var formats = [
       '{{address.cityPrefix}} {{name.firstName}}{{address.citySuffix}}',
       '{{address.cityPrefix}} {{name.firstName}}',
@@ -68,7 +73,12 @@ function Address (faker) {
       '{{name.lastName}}{{address.citySuffix}}'
     ];
 
-    if (!format && faker.definitions.address.city_name) {
+    if (matchingLocaleFormats && matchingLocaleFormats.length > 0)
+    {
+      formats = matchingLocaleFormats;
+    }
+
+   if (!format && faker.definitions.address.city_name && !formats.includes('{{address.cityName}}')) {
       formats.push('{{address.cityName}}');
     }
 


### PR DESCRIPTION
This commits allows formats defined in 'city.js' files to be used when generating random city names.

The problem is that many locales have strings inside 'city.js' files that cannot be used as format strings;
Therefore the randomly generated results may contain the actual strings contained inside 'city.js' files.

https://github.com/Marak/faker.js/blob/master/lib/locales/en/address/city.js#L1-L6

What are these strings actually used for?

If they are not actually used anywhere, would it be ok to correct them (using double moustache syntax)  so they can be used to generate city names?
 
If necessary i could look into a function to validate format strings.

Thank you