### PR TITLE
Improve faker.random.arrayElements performance

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -82,14 +82,20 @@ function Random (faker, seed) {
         count = 0;
       }
 
-      var arrayCopy = array.slice();
-      var countToRemove = arrayCopy.length - count;
-      for (var i = 0; i < countToRemove; i++) {
-        var indexToRemove = faker.datatype.number({ max: arrayCopy.length - 1 });
-        arrayCopy.splice(indexToRemove, 1);
+      var arrayCopy = array.slice(0);
+      var i = array.length;
+      var min = i - count;
+      var temp;
+      var index;
+
+      while (i-- > min) {
+        index = Math.floor((i + 1) * faker.datatype.float({ min: 0, max: 1 }));
+        temp = arrayCopy[index];
+        arrayCopy[index] = arrayCopy[i];
+        arrayCopy[i] = temp;
       }
 
-      return arrayCopy;
+      return arrayCopy.slice(min);
   };
 
   /**

--- a/lib/random.js
+++ b/lib/random.js
@@ -89,7 +89,7 @@ function Random (faker, seed) {
       var index;
 
       while (i-- > min) {
-        index = Math.floor((i + 1) * faker.datatype.float({ min: 0, max: 1 }));
+        index = Math.floor((i + 1) * faker.datatype.float({ min: 0, max: 0.99 }));
         temp = arrayCopy[index];
         arrayCopy[index] = arrayCopy[i];
         arrayCopy[i] = temp;


### PR DESCRIPTION
`faker.random.arrayElements` has performance issues when dealing with large arrays.

The following implementation significantly improves performance.

Performance tests for an array of 200000 items:
| Count  | Old implementation | New implementation |
| -      | -                  | -                  |
| 20000  |      1872ms        |       10ms         |
| 40000  |      1643ms        |       9ms          |
| 60000  |      1542ms        |       9ms          |
| 80000  |      1429ms        |       10ms         |
| 100000 |      1270ms        |       12ms         |
| 120000 |      1099ms        |       15ms         |
| 140000 |      1013ms        |       25ms         |
| 160000 |      623ms         |       23ms         |
| 180000 |      333ms         |       22ms         |

Performance tests source code is available [here](https://codesandbox.io/s/faker-performance-test-oxsm4?file=/src/index.js)