### PR TITLE
Feature to add only numeric or only alpha on faker.random.alphaNumeric

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -220,7 +220,7 @@ function Random (faker, seed) {
    *
    * @method faker.random.alpha
    * @param {Object?} options defaults to { count:1, bannedChars: [], upcase: false }
-   * @param {number} options.count defines a lenght
+   * @param {number?} options.count defines a length
    * @param {Array?} options.bannedChars array of characters which should be banned in new string
    * @param {boolean?} options.upcase converts to uppercase
    *
@@ -230,8 +230,7 @@ function Random (faker, seed) {
       options={ count: 1 };
     } else if (typeof options === "number") {
       options={ count: options };
-    }
-    if (typeof options.count === "undefined") {
+    } else if (typeof options.count === "undefined") {
       options.count = 1;
     }
     if (typeof options.bannedChars ==="undefined"){

--- a/lib/random.js
+++ b/lib/random.js
@@ -258,8 +258,13 @@ function Random (faker, seed) {
    *
    * @method faker.random.alphaNumeric
    * @param {number} count defaults to 1
-   * {mixed} options // defaults to { bannedChars: [] }
+   * @param {mixed} options defaults to { bannedChars: [], numeric: true, alpha: true, symbols: false }
+   * 
    * options.bannedChars - array of characters which should be banned in new string
+   * 
+   * options.numeric - boolean that defines whether numeric characters will be generated
+   * 
+   * options.alpha - boolean that defines whether alpha characters will be generated
    */
   this.alphaNumeric = function alphaNumeric(count, options) {
     if (typeof count === "undefined") {
@@ -271,16 +276,32 @@ function Random (faker, seed) {
     if (typeof options.bannedChars ==="undefined"){
       options.bannedChars = [];
     }
+    if (typeof options.numeric ==="undefined"){
+      options.numeric = true;
+    }
+    if (typeof options.alpha ==="undefined"){
+      options.alpha = true;
+    }
 
     var wholeString = "";
-    var charsArray = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+    var numbers = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+    var letters = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+    var charsArray = []
     if(options) {
+      if(options.numeric){
+        charsArray = charsArray.concat(numbers);;
+      }
+      if(options.alpha){
+        charsArray = charsArray.concat(letters);
+      }
       if (options.bannedChars) {
         charsArray = arrayRemove(charsArray, options.bannedChars);
       }
     }
-    for(var i = 0; i < count; i++) {
-      wholeString += faker.random.arrayElement(charsArray);
+    if(charsArray.length>0){
+      for(var i = 0; i < count; i++) {
+        wholeString += faker.random.arrayElement(charsArray);
+      }
     }
 
     return wholeString;

--- a/lib/random.js
+++ b/lib/random.js
@@ -219,35 +219,30 @@ function Random (faker, seed) {
    * alpha. returns lower/upper alpha characters based count and upcase options
    *
    * @method faker.random.alpha
-   * @param {mixed} options // defaults to { count: 1, upcase: false, bannedChars: [] }
+   * @param {Object?} options defaults to { count:1, bannedChars: [], upcase: false }
+   * @param {number} options.count defines a lenght
+   * @param {Array?} options.bannedChars array of characters which should be banned in new string
+   * @param {boolean?} options.upcase converts to uppercase
+   *
    */
   this.alpha = function alpha(options) {
-    if (typeof options === "undefined") {
-      options = {
-        count: 1
-      };
+    if(typeof options ==="undefined"){
+      options={ count: 1 };
     } else if (typeof options === "number") {
-      options = {
-        count: options,
-      };
-    } else if (typeof options.count === "undefined") {
-      options.count = 1;
+      options={ count: options };
     }
-
-    if (typeof options.upcase === "undefined") {
-      options.upcase = false;
+    if (typeof options.count === "undefined") {
+      options.count = 1;
     }
     if (typeof options.bannedChars ==="undefined"){
       options.bannedChars = [];
     }
-
-    var wholeString = "";
-    var charsArray = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
-    if(options.bannedChars){
-      charsArray = arrayRemove(charsArray,options.bannedChars);
+    if (typeof options.upcase === "undefined") {
+      options.upcase = false;
     }
+    var wholeString = "";
     for(var i = 0; i < options.count; i++) {
-      wholeString += faker.random.arrayElement(charsArray);
+      wholeString += faker.random.alphaNumeric(1,{numeric: false, bannedChars:options.bannedChars})
     }
 
     return options.upcase ? wholeString.toUpperCase() : wholeString;
@@ -258,13 +253,11 @@ function Random (faker, seed) {
    *
    * @method faker.random.alphaNumeric
    * @param {number} count defaults to 1
-   * @param {mixed} options defaults to { bannedChars: [], numeric: true, alpha: true, symbols: false }
+   * @param {Object?} options defaults to { bannedChars: [], numeric: true, alpha: true }
+   * @param {Array?} options.bannedChars array of characters which should be banned in new string
+   * @param {boolean?} options.numeric defines whether numeric characters will be generated
+   * @param {boolean?} options.alpha defines whether alpha characters will be generated
    * 
-   * options.bannedChars - array of characters which should be banned in new string
-   * 
-   * options.numeric - boolean that defines whether numeric characters will be generated
-   * 
-   * options.alpha - boolean that defines whether alpha characters will be generated
    */
   this.alphaNumeric = function alphaNumeric(count, options) {
     if (typeof count === "undefined") {
@@ -286,7 +279,7 @@ function Random (faker, seed) {
     var wholeString = "";
     var numbers = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
     var letters = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
-    var charsArray = []
+    var charsArray = [];
     if(options) {
       if(options.numeric){
         charsArray = charsArray.concat(numbers);;

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -164,14 +164,14 @@ describe("random.js", function () {
     });
 
     it('should be able to ban some characters', function() {
-      var alphaText = alpha(5,{bannedChars:['a', 'p']});
+      var alphaText = alpha({count:5, bannedChars:['a', 'p']});
       assert.ok(alphaText.length === 5);
-      assert.ok(alphaText.match(/[b-oq-z]/));
+      assert.doesNotMatch(alphaText, /[ap]/)
     });
     it('should be able handle mistake in banned characters array', function() {
-      var alphaText = alpha(5,{bannedChars:['a', 'a', 'p']});
+      var alphaText = alpha({count:5, bannedChars:['a', 'a', 'p']});
       assert.ok(alphaText.length === 5);
-      assert.ok(alphaText.match(/[b-oq-z]/));
+      assert.doesNotMatch(alphaText, /[ap]/)
     });
   });
 

--- a/test/random.unit.js
+++ b/test/random.unit.js
@@ -189,12 +189,32 @@ describe("random.js", function () {
     it('should be able to ban some characters', function() {
       var alphaText = alphaNumeric(5,{bannedChars:['a','p']});
       assert.ok(alphaText.length === 5);
-      assert.ok(alphaText.match(/[b-oq-z]/));
+      assert.doesNotMatch(alphaText, /[ap]/)
     });
     it('should be able handle mistake in banned characters array', function() {
       var alphaText = alphaNumeric(5,{bannedChars:['a','p','a']});
       assert.ok(alphaText.length === 5);
-      assert.ok(alphaText.match(/[b-oq-z]/));
+      assert.doesNotMatch(alphaText, /[apa]/)
+    });
+    it('should return both alpha and numeric characters by default', function() {
+      var alphaText = alphaNumeric(10);
+      assert.ok(alphaText.length === 10);
+      assert.ok(alphaText.match(/^[a-z0-9]+$/));
+    });
+    it('should be able to remove alpha characters', function() {
+      var numericText = alphaNumeric(10,{alpha:false});
+      assert.ok(numericText.length === 10);
+      assert.match(numericText,/^[0-9]+$/)
+    });
+    it('should be able to remove numeric characters', function() {
+      var alphaText = alphaNumeric(10,{numeric:false});
+      assert.ok(alphaText.length === 10);
+      assert.match(alphaText, /^[a-z]+$/)
+    });
+    it('should return an empty string if both alpha and numeric are removed', function() {
+      var alphaText = alphaNumeric(10,{numeric:false, alpha:false});
+      console.log(alphaText)
+      assert.ok(alphaText.length === 0);
     });
   });
 


### PR DESCRIPTION
Hi, I wanted to create a way to generate a string with only random digits.
So I added two booleans to the options of alphaNumeric: 
options.numeric
options.alpha

Tests: 
I've figured out that alphaNumeric tests were returning a false positive as shown below:
(note that while testing I added the bannedChars to the string and it has passed)
![image](https://user-images.githubusercontent.com/8595291/114262529-dca79580-99b6-11eb-8782-0e528211a25c.png)
It was happening because the regex was not verifying if the bannedChars were not in the string. It was only matching that characters between [b-oq-z] were in the string.

I fixed that in the alphanumeric and alpha functions.
I fixed also alpha tests that were passing 2 params to the function, as it was ignoring the options.bannedChars param.
