### PR TITLE
Remove deprecated "random" entries from Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -255,21 +255,6 @@ https://github.com/faker/faker-cloud
   * phoneNumber
   * phoneNumberFormat
   * phoneFormats
-* random
-  * number
-  * float
-  * arrayElement
-  * arrayElements
-  * objectElement
-  * uuid
-  * boolean
-  * word
-  * words
-  * image
-  * locale
-  * alpha
-  * alphaNumeric
-  * hexaDecimal
 * system
   * fileName
   * commonFileName


### PR DESCRIPTION
Seeing deprecation messages when trying to use faker.random.x -- Do we need any other updates, perhaps here as well?   http://marak.github.io/faker.js/