### PR TITLE
feat: add uniqueArray helper function

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -216,6 +216,35 @@ var Helpers = function (faker) {
   };
 
   /**
+   * takes an array of strings or function that returns a string
+   * and outputs a unique array of strings based on that source
+   * @example uniqueArray(faker.random.word, 50)
+   * @example uniqueArray(faker.definitions.name.first_name, 6)
+   * @example uniqueArray(["Hello", "World", "Goodbye"], 2)
+   * @method faker.helpers.uniqueArray
+   * @param {string[] | function => string} source
+   * @param {number} length
+   * @returns {string[]}
+  */
+  self.uniqueArray = function(source, length) {
+    if (Array.isArray(source)) {
+      const set = new Set(source);
+      const array = Array.from(set);
+      return faker.helpers.shuffle(array).splice(0, length);
+    }
+    const set = new Set();
+    try {
+      if (typeof source === "function") {
+        while (set.size < length) {
+          set.add(source());
+        }
+      }
+    } finally {
+      return Array.from(set);
+    }
+  };
+
+  /**
    * mustache
    *
    * @method faker.helpers.mustache

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -58,6 +58,54 @@ describe("helpers.js", function () {
     });
   });
 
+  describe("uniqueArray()", function () {
+    it("custom array returns unique array", function () {
+      var input = ["a", "a", "a", "a,", "a", "a", "a", "a", "b"];
+      var length = 2;
+      var unique = faker.helpers.uniqueArray(input, length);
+      assert.strictEqual(unique.length, length);
+      assert.strictEqual(new Set(unique).size, length);
+    });
+
+    it("definition array returns unique array", function () {
+      var length = faker.datatype.number({ min: 1, max: 6 });
+      var unique = faker.helpers.uniqueArray(faker.definitions.hacker.noun, length);
+      assert.strictEqual(unique.length, length);
+      assert.strictEqual(new Set(unique).size, length);
+    });
+
+    it("function returns unique array", function () {
+      var length = faker.datatype.number({ min: 1, max: 6 });
+      var unique = faker.helpers.uniqueArray(faker.lorem.word, length);
+      assert.strictEqual(unique.length, length);
+      assert.strictEqual(new Set(unique).size, length);
+    });
+
+    it("empty array returns empty array", function () {
+      var input = [];
+      var length = faker.datatype.number({ min: 1, max: 6 });
+      var unique = faker.helpers.uniqueArray(input, length);
+      assert.strictEqual(unique.length, input.length);
+      assert.strictEqual(new Set(unique).size, input.length);
+    });
+
+    it("length longer than source returns max length", function () {
+      var input = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+      var length = input.length + 1;
+      var unique = faker.helpers.uniqueArray(input, length);
+      assert.strictEqual(unique.length, input.length);
+      assert.strictEqual(new Set(unique).size, input.length);
+    });
+
+    it("works as expected when seeded", function () {
+      var input = ["a", "a", "a", "a", "a", "f", "g", "h", "i", "j"];
+      var length = 5;
+      faker.seed(100);
+      var unique = faker.helpers.uniqueArray(input, length);
+      assert.deepStrictEqual(unique, ["g", "a", "i", "f", "j"]);
+    });
+  });
+
   describe("slugify()", function () {
     it("removes unwanted characters from URI string", function () {
       assert.strictEqual(faker.helpers.slugify("Aiden.Harªann"), "Aiden.Harann");


### PR DESCRIPTION
Hi there!

We use faker to generate our test data, and often times we use unique string values as both labels as well as keys in React.

For that we generally use `faker.random.word` or `faker.lorem.word`. The issue here is that calling this multiple times doesn't ensure uniqueness, and there's a chance that the same string gets picked twice. This then causes the tests to fail, as keys need to be unique.

While we could use something like `uuid`, it doesn't emulate our test data as well (and isn't very human readable)

To solve for that I've added a utility that will return a unique array of strings, based on a source and desired length.
The source can be a `faker.definitions` array, custom string array, or a function that generates a string.

If the desired length is greater than the source's length (or possible output, in the case of a function) it will return as many unique entries as it can. It was important to have this function be
* Random
* Unique
