### PR TITLE
feat: protocol defaults to a secure location

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -42,12 +42,12 @@ var Image = function (faker) {
    * @param {boolean} randomize
    * @method faker.image.imageUrl
    */
-  self.imageUrl = function (width, height, category, randomize, https) {
+  self.imageUrl = function (width, height, category, randomize, http) {
     var width = width || 640;
     var height = height || 480;
-    var protocol = 'http://';
-    if (typeof https !== 'undefined' && https === true) {
-      protocol = 'https://';
+    var protocol = 'https://';
+    if (typeof http !== 'undefined' && http === true) {
+      protocol = 'http://';
     }
     var url = protocol + 'placeimg.com/' + width + '/' + height;
     if (typeof category !== 'undefined') {


### PR DESCRIPTION
Now a user has to actively choose to have an insecure protocol URL.  
Omitting the parameter returns a secure protocol.