### PR TITLE
Add dash between Rolls Royce vehicle manufacturer

### DIFF
--- a/lib/locales/en/vehicle/manufacturer.js
+++ b/lib/locales/en/vehicle/manufacturer.js
@@ -25,7 +25,7 @@ module["exports"] = [
   "Nissan",
   "Polestar",
   "Porsche",
-  "Rolls Royce",
+  "Rolls-Royce",
   "Smart",
   "Tesla",
   "Toyota",


### PR DESCRIPTION
I ran into issues with this when testing against a codebase which has its own list of vehicle manufacturers. It seems pretty clear from a quick google search that 'Rolls Royce" should indeed be "Rolls-Royce". See this page directly from the manufacturer's website

![Screen Shot 2021-07-05 at 10 44 42 AM](https://user-images.githubusercontent.com/11297614/124488580-04bc5000-dd7e-11eb-9985-f60909c59767.png)

Furthermore wikipedia indicates the same: https://en.wikipedia.org/wiki/Rolls-Royce_Motor_Cars
