### PR TITLE
[Fix #1101]  zipcodes for eastern US states < 5 long

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -1,3 +1,6 @@
+const { zip } = require("lodash");
+const { string } = require("optimist");
+
 /**
  *
  * @namespace faker.address
@@ -38,8 +41,19 @@ function Address (faker) {
    */
   this.zipCodeByState = function (state) {
     var zipRange = faker.definitions.address.postcode_by_state[state];
+    // Due to lack of ES6 pad start use padstart polyfill logic.
     if (zipRange) {
-      return faker.datatype.number(zipRange);
+      var workingZip = String(faker.datatype.number(zipRange));
+      if (workingZip.length === 5) {
+        return workingZip;
+      } else {
+        var targetLength = 5 - workingZip.length;
+        var padString = '0';
+        if (targetLength > padString.length) {
+          padString += padString.repeat(targetLength / padString.length);
+        }
+        return padString.slice(0, targetLength) + workingZip;
+      }   
     }
     return faker.address.zipCode();
   }

--- a/practicefaker.js
+++ b/practicefaker.js
@@ -1,0 +1,4 @@
+const faker = require('./index.js')
+faker.locale = 'en_US'
+console.log(faker.address.zipCodeByState('RI'));
+console.log(typeof(faker.address.zipCodeByState('CA')))

--- a/test/address.unit.js
+++ b/test/address.unit.js
@@ -302,6 +302,18 @@ describe("address.js", function () {
       assert.ok(faker.address.zipCode.called);
       faker.address.zipCode.restore();
     });
+
+    it("returns a zipcode with a length of five.", function () {
+      // Certain states were returning a zip < 5.
+      faker.locale = "en_US";
+      var states = ["PR", "RI", "MA"];
+      var zipCode1 = faker.address.zipCodeByState(states[0]);
+      assert.ok(zipCode1.length === 5);
+      var zipCode2 = faker.address.zipCodeByState(states[1]);
+      assert.ok(zipCode2.length === 5);
+      var zipCode3 = faker.address.zipCodeByState(states[2]);
+      assert.ok(zipCode3.length === 5);
+    });
   });
 
   describe("latitude()", function () {


### PR DESCRIPTION
Here's a link to the discussion around this PR previously. https://github.com/Marak/faker.js/pull/1139. Basically needed to convert from es6->es5, I didn't get around to it and someone @'d me about it.  This should fix the issue. I included testing. Have a good weekend!