### PR TITLE
fix: fixed vin generator

### DIFF
--- a/lib/vehicle.js
+++ b/lib/vehicle.js
@@ -88,7 +88,7 @@ var Vehicle = function (faker) {
       faker.random.alphaNumeric(10, {bannedChars:bannedChars}) +
       faker.random.alpha({ count: 1, upcase: true ,bannedChars:bannedChars}) +
       faker.random.alphaNumeric(1, {bannedChars:bannedChars}) +
-      faker.datatype.number({ min: 10000, max: 100000}) // return five digit #
+      faker.datatype.number({ min: 10000, max: 99999}) // return five digit #
     ).toUpperCase();
   };
 


### PR DESCRIPTION
VIN generator can generate invalid VIN because of wrong inclusive max value (which is 6 digits instead of 5).