### PR TITLE
Remove duplicated city suffix

### DIFF
--- a/lib/locales/en/address/city_suffix.js
+++ b/lib/locales/en/address/city_suffix.js
@@ -13,7 +13,6 @@ module["exports"] = [
   "stad",
   "furt",
   "chester",
-  "mouth",
   "fort",
   "haven",
   "side",


### PR DESCRIPTION
The name "mouth" shows up twice in city_suffix.js