### PR TITLE
Bump generated User-Agent version ranges to match reality

### DIFF
--- a/vendor/user-agent.js
+++ b/vendor/user-agent.js
@@ -131,10 +131,10 @@ exports.generate = function generate(faker) {
       return rnd(3, 7) + '.' + rnd(0, 1);
     },
     osx: function (delim) {
-      return [10, rnd(5, 10), rnd(0, 9)].join(delim || '.');
+      return [rnd(10, 12), rnd(5, 10), rnd(0, 9)].join(delim || '.');
     },
     chrome: function () {
-      return [rnd(13, 39), 0, rnd(800, 899), 0].join('.');
+      return [rnd(30, 109), 0, rnd(800, 899), 0].join('.');
     },
     presto: function () {
       return '2.9.' + rnd(160, 190);


### PR DESCRIPTION
Browsers received updates more frequently than this file, and the values it contains no longer reflect reality.
Namely:
- Chrome is almost reaching version 100 (which will cause issues, for sure, see https://developer.chrome.com/blog/force-major-version-to-100/)
- macOS is no longer pinned to 10.x, with Big Sur (11) and Monterey (12) released in the last two years.