### PR TITLE
feat: add support to "unique" method  on faker.fake interpolation

### DIFF
--- a/lib/fake.js
+++ b/lib/fake.js
@@ -3,8 +3,7 @@
 
 */
 
-function Fake (faker) {
-  
+function Fake(faker) {
   /**
    * Generator method for combining faker methods based on string input
    *
@@ -22,18 +21,18 @@ function Fake (faker) {
    * @method faker.fake
    * @param {string} str
    */
-  this.fake = function fake (str) {
+  this.fake = function fake(str) {
     // setup default response as empty string
-    var res = '';
+    var res = "";
 
     // if incoming str parameter is not provided, return error message
-    if (typeof str !== 'string' || str.length === 0) {
-      throw new Error('string parameter is required!');
+    if (typeof str !== "string" || str.length === 0) {
+      throw new Error("string parameter is required!");
     }
 
     // find first matching {{ and }}
-    var start = str.search('{{');
-    var end = str.search('}}');
+    var start = str.search("{{");
+    var end = str.search("}}");
 
     // if no {{ and }} is found, we are done
     if (start === -1 || end === -1) {
@@ -44,29 +43,34 @@ function Fake (faker) {
 
     // extract method name from between the {{ }} that we found
     // for example: {{name.firstName}}
-    var token = str.substr(start + 2,  end - start - 2);
-    var method = token.replace('}}', '').replace('{{', '');
+    var token = str.substr(start + 2, end - start - 2);
+    var method = token.replace("}}", "").replace("{{", "");
 
     // console.log('method', method)
 
     // extract method parameters
     var regExp = /\(([^)]+)\)/;
     var matches = regExp.exec(method);
-    var parameters = '';
+    var parameters = "";
     if (matches) {
-      method = method.replace(regExp, '');
+      method = method.replace(regExp, "");
       parameters = matches[1];
     }
 
     // split the method into module and function
-    var parts = method.split('.');
+    var parts = method.split(".");
 
     if (typeof faker[parts[0]] === "undefined") {
-      throw new Error('Invalid module: ' + parts[0]);
+      throw new Error("Invalid module: " + parts[0]);
+    }
+
+    var isUnique = parts[0] === "unique";
+    if (isUnique) {
+      parts.shift();
     }
 
     if (typeof faker[parts[0]][parts[1]] === "undefined") {
-      throw new Error('Invalid method: ' + parts[0] + "." + parts[1]);
+      throw new Error("Invalid method: " + parts[0] + "." + parts[1]);
     }
 
     // assign the function from the module.function namespace
@@ -79,29 +83,36 @@ function Fake (faker) {
     // Note: we experience a small performance hit here due to JSON.parse try / catch
     // If anyone actually needs to optimize this specific code path, please open a support issue on github
     try {
-      params = JSON.parse(parameters)
+      params = JSON.parse(parameters);
     } catch (err) {
       // since JSON.parse threw an error, assume parameters was actually a string
       params = parameters;
     }
 
+    var self = this;
+    var call = function call() {
+      if (typeof params === "string" && params.length === 0) {
+        return fn.call(self);
+      } else {
+        return fn.call(self, params);
+      }
+    };
+
     var result;
-    if (typeof params === "string" && params.length === 0) {
-      result = fn.call(this);
+    if (isUnique) {
+      result = faker.unique(call);
     } else {
-      result = fn.call(this, params);
+      result = call();
     }
 
     // replace the found tag with the returned fake value
-    res = str.replace('{{' + token + '}}', result);
+    res = str.replace("{{" + token + "}}", result);
 
     // return the response recursively until we are done finding all tags
-    return fake(res);    
-  }
-  
+    return fake(res);
+  };
+
   return this;
-  
-  
 }
 
-module['exports'] = Fake;
+module["exports"] = Fake;

--- a/test/fake.unit.js
+++ b/test/fake.unit.js
@@ -1,18 +1,20 @@
-if (typeof module !== 'undefined') {
-  var assert = require('assert');
-  var sinon = require('sinon');
-  var faker = require('../index');
+if (typeof module !== "undefined") {
+  var assert = require("assert");
+  var sinon = require("sinon");
+  var faker = require("../index");
 }
 
 describe("fake.js", function () {
   describe("fake()", function () {
     it("replaces a token with a random value for a method with no parameters", function () {
-      var name = faker.fake('{{phone.phoneNumber}}');
+      var name = faker.fake("{{phone.phoneNumber}}");
       assert.ok(name.match(/\d/));
     });
 
     it("replaces multiple tokens with random values for methods with no parameters", function () {
-      var name = faker.fake('{{helpers.randomize}}{{helpers.randomize}}{{helpers.randomize}}');
+      var name = faker.fake(
+        "{{helpers.randomize}}{{helpers.randomize}}{{helpers.randomize}}"
+      );
       assert.ok(name.match(/[abc]{3}/));
     });
 
@@ -30,22 +32,48 @@ describe("fake.js", function () {
 
     it("does not allow undefined parameters", function () {
       assert.throws(function () {
-        faker.fake()
+        faker.fake();
       }, Error);
     });
 
     it("does not allow invalid module name", function () {
       assert.throws(function () {
-        faker.fake('{{foo.bar}}')
+        faker.fake("{{foo.bar}}");
       }, Error);
     });
 
     it("does not allow invalid method name", function () {
       assert.throws(function () {
-        faker.fake('{{address.foo}}')
+        faker.fake("{{address.foo}}");
       }, Error);
     });
 
-
+    it("replaces a token using unique method", function () {
+      var options = [];
+      var first = faker.fake(
+        '{{unique.helpers.randomize(["one", "two", "three"])}}'
+      );
+      assert.ok(!options.includes(first));
+      options.push(first);
+      var second = faker.fake(
+        '{{unique.helpers.randomize(["one", "two", "three"])}}'
+      );
+      assert.ok(!options.includes(second));
+      options.push(second);
+      var third = faker.fake(
+        '{{unique.helpers.randomize(["one", "two", "three"])}}'
+      );
+      assert.ok(!options.includes(third));
+      options.push(third);
+      assert.throws(
+        function () {
+          faker.fake('{{unique.helpers.randomize(["one", "two", "three"])}}');
+        },
+        {
+          message:
+            /May not be able to generate any more unique values with current settings/,
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
I added support to unique method on faker.fake interpolation like "{{unique.music.genre}}".
We just need to add "unique." before any method.
This helps on tests that need unique values by execution.